### PR TITLE
refactor: Convert some internal error usages to panic

### DIFF
--- a/examples/smart-escrows/atomic_swap/atomic_swap1/src/lib.rs
+++ b/examples/smart-escrows/atomic_swap/atomic_swap1/src/lib.rs
@@ -10,7 +10,6 @@ use xrpl_wasm_stdlib::core::ledger_objects::traits::{CurrentEscrowFields, Escrow
 use xrpl_wasm_stdlib::core::locator::Locator;
 use xrpl_wasm_stdlib::core::types::contract_data::XRPL_CONTRACT_DATA_SIZE;
 use xrpl_wasm_stdlib::host;
-use xrpl_wasm_stdlib::host::Error::InternalError;
 use xrpl_wasm_stdlib::host::error_codes::match_result_code_with_expected_bytes;
 use xrpl_wasm_stdlib::host::get_tx_nested_field;
 use xrpl_wasm_stdlib::host::trace::{DataRepr, trace_data, trace_num};
@@ -72,7 +71,9 @@ pub fn get_first_memo() -> Result<Option<(ContractData, usize)>> {
 
     match result_code {
         result_code if result_code > 0 => Ok(Some((data, result_code as usize))),
-        0 => Err(InternalError),
+        // Zero length is a present-but-empty memo (protocol-valid input); treat it the
+        // same as an absent field and let the caller decide.
+        0 => Ok(None),
         result_code => Err(Error::from_code(result_code)),
     }
 }

--- a/examples/smart-escrows/freelancer_escrow/src/lib.rs
+++ b/examples/smart-escrows/freelancer_escrow/src/lib.rs
@@ -193,8 +193,11 @@ fn read_intent() -> Result<Intent> {
         )
     };
     if code <= 0 {
+        // Zero length is a present-but-empty memo (protocol-valid input): no intent byte
+        // was provided, which is an invalid request for this contract — same as an
+        // unrecognized intent byte below.
         return Err(if code == 0 {
-            Error::InternalError
+            Error::InvalidParams
         } else {
             Error::from_code(code)
         });

--- a/examples/smart-escrows/nft_owner/src/lib.rs
+++ b/examples/smart-escrows/nft_owner/src/lib.rs
@@ -7,7 +7,6 @@ use xrpl_wasm_stdlib::core::ledger_objects::current_escrow;
 use xrpl_wasm_stdlib::core::ledger_objects::traits::CurrentEscrowFields;
 use xrpl_wasm_stdlib::core::locator::Locator;
 use xrpl_wasm_stdlib::core::types::nft::{NFT_ID_SIZE, NFToken};
-use xrpl_wasm_stdlib::host::Error::InternalError;
 use xrpl_wasm_stdlib::host::get_tx_nested_field;
 use xrpl_wasm_stdlib::host::trace::{DataRepr, trace_data, trace_num};
 use xrpl_wasm_stdlib::host::{Error, Result, Result::Err, Result::Ok};
@@ -34,7 +33,9 @@ pub fn get_first_memo() -> Result<Option<ContractData>> {
         result_code if result_code > 0 => {
             Ok(Some(data)) // <-- Move the buffer into an AccountID
         }
-        0 => Err(InternalError),
+        // Zero length is a present-but-empty memo (protocol-valid input); treat it the
+        // same as an absent field and let the caller decide.
+        0 => Ok(None),
         result_code => Err(Error::from_code(result_code)),
     }
 }

--- a/xrpl-wasm-stdlib/src/core/current_tx/mod.rs
+++ b/xrpl-wasm-stdlib/src/core/current_tx/mod.rs
@@ -362,7 +362,8 @@ mod tests {
     }
 
     #[test]
-    fn test_field_getter_returns_err_on_size_mismatch() {
+    #[should_panic]
+    fn test_field_getter_panics_on_size_mismatch() {
         let mut mock = MockHostBindings::new();
         mock.expect_get_tx_field()
             .with(eq::<i32>(sfield::Sequence.into()), always(), eq(4))
@@ -371,7 +372,7 @@ mod tests {
 
         let _guard = setup_mock(mock);
 
-        assert!(u32::get_from_current_tx(sfield::Sequence).is_err());
+        let _ = u32::get_from_current_tx(sfield::Sequence);
     }
 
     // get_field / get_field_optional are thin wrappers over get_from_current_tx / get_from_current_tx_optional,

--- a/xrpl-wasm-stdlib/src/core/current_tx/traits.rs
+++ b/xrpl-wasm-stdlib/src/core/current_tx/traits.rs
@@ -233,7 +233,13 @@ pub trait TransactionCommonFields {
     /// Returns a `Result<Option<PublicKey>>` where:
     /// * `Ok(Some(PublicKey))` - The 33-byte compressed public key for single-signature transactions
     /// * `Ok(None)` - Empty SigningPubKey field, indicating a multi-signature transaction
-    /// * `Err(Error)` - If the field cannot be retrieved or has an unexpected size (not 0 or 33 bytes)
+    /// * `Err(Error)` - If the field cannot be retrieved
+    ///
+    /// # Panics
+    ///
+    /// Panics if the field is present with a length other than 0 or 33 bytes. rippled's
+    /// preflight rejects such transactions before they are applied, so this is an internal
+    /// invariant violation rather than recoverable input.
     ///
     /// # Security Note
     ///
@@ -244,9 +250,8 @@ pub trait TransactionCommonFields {
         get_field(sfield::SigningPubKey).and_then(|blob| match blob.len {
             0 => Result::Ok(None), // Multi-signature transaction
             33 => Result::Ok(Some(PublicKey::from(blob.data))), // Single-signature transaction
-            _ => Result::Err(crate::host::Error::from_code(
-                crate::host::error_codes::INTERNAL_ERROR,
-            )),
+            // Unreachable in practice (see `# Panics`); fail fast if the invariant breaks.
+            len => panic!("internal invariant violated: SigningPubKey has unexpected length {len} (expected 0 or 33)"),
         })
     }
 
@@ -615,31 +620,33 @@ mod tests {
                 assert!(escrow.get_offer_sequence().is_ok());
             }
 
-            #[test]
-            fn test_mandatory_fields_return_error_when_zero_length() {
-                let mut mock = MockHostBindings::new();
+            // Zero length for a mandatory fixed-size field panics (byte mismatch). One test
+            // per field, since `#[should_panic]` only catches the first panic.
 
-                // get_owner - returns 0 (zero length)
+            #[test]
+            #[should_panic]
+            fn test_get_owner_panics_when_zero_length() {
+                let mut mock = MockHostBindings::new();
                 mock.expect_get_tx_field()
                     .with(eq(sfield::Owner), always(), eq(ACCOUNT_ID_SIZE))
-                    .times(1)
-                    .returning(|_, _, _| 0);
-                // get_offer_sequence - returns 0 (zero length)
-                mock.expect_get_tx_field()
-                    .with(eq(sfield::OfferSequence), always(), eq(4))
-                    .times(1)
                     .returning(|_, _, _| 0);
 
                 let _guard = setup_mock(mock);
 
-                let escrow = EscrowFinish;
+                let _ = EscrowFinish.get_owner();
+            }
 
-                // Mandatory fields should return Err when zero length (INTERNAL_ERROR due to byte mismatch)
-                let owner_result = escrow.get_owner();
-                assert!(owner_result.is_err());
+            #[test]
+            #[should_panic]
+            fn test_get_offer_sequence_panics_when_zero_length() {
+                let mut mock = MockHostBindings::new();
+                mock.expect_get_tx_field()
+                    .with(eq(sfield::OfferSequence), always(), eq(4))
+                    .returning(|_, _, _| 0);
 
-                let offer_seq_result = escrow.get_offer_sequence();
-                assert!(offer_seq_result.is_err());
+                let _guard = setup_mock(mock);
+
+                let _ = EscrowFinish.get_offer_sequence();
             }
 
             #[test]
@@ -1066,33 +1073,64 @@ mod tests {
                 assert!(tx.get_txn_signature().is_ok());
             }
 
-            #[test]
-            fn test_mandatory_fields_return_error_when_zero_length() {
-                let mut mock = MockHostBindings::new();
+            // Zero length for a mandatory fixed-size field panics (byte mismatch). One test
+            // per field, since `#[should_panic]` only catches the first panic.
 
-                // get_account - returns 0 (zero length)
+            #[test]
+            #[should_panic]
+            fn test_get_account_panics_when_zero_length() {
+                let mut mock = MockHostBindings::new();
                 mock.expect_get_tx_field()
                     .with(eq(sfield::Account), always(), eq(ACCOUNT_ID_SIZE))
-                    .times(1)
                     .returning(|_, _, _| 0);
-                // get_transaction_type - returns 0 (zero length)
+
+                let _guard = setup_mock(mock);
+                let _ = EscrowFinish.get_account();
+            }
+
+            #[test]
+            #[should_panic]
+            fn test_get_transaction_type_panics_when_zero_length() {
+                let mut mock = MockHostBindings::new();
                 mock.expect_get_tx_field()
                     .with(eq(sfield::TransactionType), always(), eq(2))
-                    .times(1)
                     .returning(|_, _, _| 0);
-                // get_computation_allowance - returns 0 (zero length)
+
+                let _guard = setup_mock(mock);
+                let _ = EscrowFinish.get_transaction_type();
+            }
+
+            #[test]
+            #[should_panic]
+            fn test_get_computation_allowance_panics_when_zero_length() {
+                let mut mock = MockHostBindings::new();
                 mock.expect_get_tx_field()
                     .with(eq(sfield::ComputationAllowance), always(), eq(4))
-                    .times(1)
                     .returning(|_, _, _| 0);
+
+                let _guard = setup_mock(mock);
+                let _ = EscrowFinish.get_computation_allowance();
+            }
+
+            #[test]
+            #[should_panic]
+            fn test_get_sequence_panics_when_zero_length() {
+                let mut mock = MockHostBindings::new();
+                mock.expect_get_tx_field()
+                    .with(eq(sfield::Sequence), always(), eq(4))
+                    .returning(|_, _, _| 0);
+
+                let _guard = setup_mock(mock);
+                let _ = EscrowFinish.get_sequence();
+            }
+
+            #[test]
+            fn test_variable_size_fields_ok_when_zero_length() {
+                let mut mock = MockHostBindings::new();
+
                 // get_fee - returns 0 (zero length)
                 mock.expect_get_tx_field()
                     .with(eq(sfield::Fee), always(), eq(AMOUNT_SIZE))
-                    .times(1)
-                    .returning(|_, _, _| 0);
-                // get_sequence - returns 0 (zero length)
-                mock.expect_get_tx_field()
-                    .with(eq(sfield::Sequence), always(), eq(4))
                     .times(1)
                     .returning(|_, _, _| 0);
                 // get_signing_pub_key - returns 0 (zero length)
@@ -1109,28 +1147,36 @@ mod tests {
 
                 let tx = EscrowFinish;
 
-                // Fixed-size mandatory fields should return Err when zero length (byte mismatch)
-                let account_result = tx.get_account();
-                assert!(account_result.is_err());
-
-                let tx_type_result = tx.get_transaction_type();
-                assert!(tx_type_result.is_err());
-
-                let comp_allow_result = tx.get_computation_allowance();
-                assert!(comp_allow_result.is_err());
-
                 // Variable-size field (Amount) returns Ok with zero length
                 let fee_result = tx.get_fee();
                 assert!(fee_result.is_ok());
-
-                let seq_result = tx.get_sequence();
-                assert!(seq_result.is_err());
 
                 // SigningPubKey is special: zero length indicates multi-signature transaction
                 // and should return Ok(None), not an error
                 let signing_key_result = tx.get_signing_pub_key();
                 assert!(signing_key_result.is_ok());
                 assert!(signing_key_result.unwrap().is_none());
+            }
+
+            #[test]
+            #[should_panic]
+            fn test_get_signing_pub_key_panics_on_unexpected_length() {
+                let mut mock = MockHostBindings::new();
+
+                // A SigningPubKey that is neither empty (0, multisign) nor a valid key (33)
+                // can never reach a running escrow: rippled's preflight rejects it. Observing
+                // such a length is an internal invariant violation and must panic.
+                mock.expect_get_tx_field()
+                    .with(
+                        eq(sfield::SigningPubKey),
+                        always(),
+                        eq(PUBLIC_KEY_BUFFER_SIZE),
+                    )
+                    .returning(|_, _, _| 16);
+
+                let _guard = setup_mock(mock);
+
+                let _ = EscrowFinish.get_signing_pub_key();
             }
 
             #[test]

--- a/xrpl-wasm-stdlib/src/core/keylets.rs
+++ b/xrpl-wasm-stdlib/src/core/keylets.rs
@@ -1342,7 +1342,8 @@ mod tests {
     });
 
     #[test]
-    fn test_wrong_size_returns_internal_error() {
+    #[should_panic]
+    fn test_wrong_size_panics() {
         let mut mock = MockHostBindings::new();
 
         // Return 16 instead of 32 — positive but wrong size
@@ -1353,8 +1354,6 @@ mod tests {
         let _guard = setup_mock(mock);
 
         let account_id = AccountID::from([0xBB; 20]);
-        let result = account_keylet(&account_id);
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        let _ = account_keylet(&account_id);
     }
 }

--- a/xrpl-wasm-stdlib/src/core/types/amount.rs
+++ b/xrpl-wasm-stdlib/src/core/types/amount.rs
@@ -5,7 +5,7 @@ use crate::core::types::currency::Currency;
 use crate::core::types::mpt_id::MptId;
 use crate::core::types::opaque_float::OpaqueFloat;
 use crate::host;
-use crate::host::Error::InternalError;
+use crate::host::Error::InvalidParams;
 use crate::host::Result::{Err, Ok};
 use crate::host::field_helpers::{get_variable_size_field, get_variable_size_field_optional};
 use crate::host::{Result, get_current_ledger_obj_field, get_ledger_obj_field, get_tx_field};
@@ -186,12 +186,12 @@ impl Amount {
     /// - MPT: 33 bytes
     /// - IOU: 48 bytes
     ///
-    /// Returns None if the byte array is not a valid Amount.
+    /// Returns `Err(InvalidParams)` if the byte array is not a valid Amount.
     pub fn from_bytes(bytes: &[u8]) -> host::Result<Self> {
         // TODO: Move to trait!
 
         if bytes.len() != 48 {
-            return Err(InternalError);
+            return Err(InvalidParams);
         }
 
         let byte0 = bytes[0]; // Get the first byte for flag extraction
@@ -515,24 +515,43 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_amount() {
+        // A byte array whose length is not 48 is a caller/input error, reported as
+        // `InvalidParams` (not an internal invariant trip).
+        let expected = InvalidParams as i32;
+
         // Test with an empty byte array
-        assert!(Amount::from_bytes(&[]).is_err());
+        assert_eq!(Amount::from_bytes(&[]).err().unwrap().code(), expected);
 
         // Test with a byte array that's too short for XRP
-        assert!(Amount::from_bytes(&[0x40, 0, 0]).is_err());
+        assert_eq!(
+            Amount::from_bytes(&[0x40, 0, 0]).err().unwrap().code(),
+            expected
+        );
 
         // Test with a byte array that's too short for MPT
         let mut mpt_bytes = [0u8; 20];
         mpt_bytes[0] = 0x60; // MPT positive flag
-        assert!(Amount::from_bytes(&mpt_bytes).is_err());
+        assert_eq!(
+            Amount::from_bytes(&mpt_bytes).err().unwrap().code(),
+            expected
+        );
 
         // Test with a byte array that's too short for IOU
         let mut iou_bytes = [0u8; 30];
         iou_bytes[0] = 0xC0; // IOU positive flag
-        assert!(Amount::from_bytes(&iou_bytes).is_err());
+        assert_eq!(
+            Amount::from_bytes(&iou_bytes).err().unwrap().code(),
+            expected
+        );
 
         // Test with an invalid type bit pattern
-        assert!(Amount::from_bytes(&[0xA0, 0, 0, 0, 0, 0, 0, 0]).is_err());
+        assert_eq!(
+            Amount::from_bytes(&[0xA0, 0, 0, 0, 0, 0, 0, 0])
+                .err()
+                .unwrap()
+                .code(),
+            expected
+        );
     }
 
     #[test]

--- a/xrpl-wasm-stdlib/src/host/error_codes.rs
+++ b/xrpl-wasm-stdlib/src/host/error_codes.rs
@@ -1,4 +1,4 @@
-use crate::host::Error::{InternalError, PointerOutOfBounds};
+use crate::host::Error::PointerOutOfBounds;
 use crate::host::trace::trace_num;
 use crate::host::{Error, Result, Result::Err, Result::Ok};
 
@@ -131,8 +131,13 @@ where
 ///
 /// Returns a `Result<T>` where:
 /// * `Ok(T)` - Contains the value returned by the closure if result_code matches expected_num_bytes
-/// * `Err(InternalError)` - If result_code is non-negative but doesn't match expected bytes
 /// * `Err(Error)` - For negative result codes
+///
+/// # Panics
+///
+/// Panics if `result_code` is non-negative but doesn't match `expected_num_bytes`. This
+/// signals an internal invariant violation (a host or stdlib bug) for which the caller has
+/// no recoverable course of action, rather than an input error.
 ///
 /// # Note
 ///
@@ -149,7 +154,12 @@ where
 {
     match result_code {
         code if code as usize == expected_num_bytes => Ok(on_success()),
-        code if code >= 0 => Err(InternalError), // If here, this is a bug
+        // Non-negative but wrong byte count: internal invariant violation (see `# Panics`).
+        code if code >= 0 => {
+            panic!(
+                "internal invariant violated: host wrote {code} bytes but {expected_num_bytes} were expected"
+            );
+        }
         code => Err(Error::from_code(code)),
     }
 }
@@ -289,12 +299,12 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn test_match_result_code_with_expected_bytes_mismatch() {
         let expected_bytes = 32;
-        let result =
-            match_result_code_with_expected_bytes(16, expected_bytes, || "should_not_execute");
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        // A non-negative code that doesn't match the expected byte count is an internal
+        // invariant violation and must panic.
+        let _ = match_result_code_with_expected_bytes(16, expected_bytes, || "should_not_execute");
     }
 
     #[test]


### PR DESCRIPTION
Note this PR is before the Observability improvements refactoring. So it is assuming -1 is still the internal error. 

Convert internal-invariant trips to panics; reclassify input errors                        
                                                                                             
  Some sites returned Err(InternalError) for conditions that are either (a) genuine          
  invariant violations the caller can't recover from, or (b) plain input errors              
  mislabeled as internal. This cleans them up:                                               
                                                                                             
  Panic (true invariant trips — unreachable unless the host/stdlib is buggy):                
  - error_codes.rs `match_result_code_with_expected_bytes`: host returned a                  
    non-negative byte count that doesn't match the expected size.                            
  - current_tx/traits.rs `get_signing_pub_key`: SigningPubKey length other than              
    0 or 33. rippled preflight rejects such txns (temBAD_SIGNATURE) before they              
    execute, so a running escrow can never observe this.                                     
                                                                                             
  Reclassify (caller/input errors, not internal):                                            
  - amount.rs `from_bytes`: wrong-length slice → InvalidParams.                              
  - example escrows nft_owner/atomic_swap1: empty memo (host returns 0) is                   
    protocol-valid input → Ok(None), matching the Option return type and existing            
    caller handling.                                                                         
  - example escrow freelancer: empty memo → InvalidParams (its signature has no              
    Option; consistent with how it already rejects an unrecognized intent byte).             
                                                                                             
  Tests updated to #[should_panic] / assert the new codes.                                   
                                                                                             
  Why the remaining InternalError usages are unchanged:                                      
  They are not stdlib decisions — they are (1) the const/enum definition, which must         
  stay because the host itself can still return -1, propagated via Error::from_code,         
  and (2) tests that simulate the host returning INTERNAL_ERROR and assert the stdlib        
  propagates it (correct: host-reported internal errors should surface as Err, not           
  panic). No production site constructs InternalError directly anymore.     