### PR TITLE
Update Amount to work with XFloat

### DIFF
--- a/e2e-tests/float_tests/src/lib.rs
+++ b/e2e-tests/float_tests/src/lib.rs
@@ -11,11 +11,13 @@ use xrpl_wasm_stdlib::decode_hex_32;
 use xrpl_wasm_stdlib::host::trace::DataRepr::AsHex;
 use xrpl_wasm_stdlib::host::trace::{DataRepr, trace, trace_data, trace_float, trace_num};
 use xrpl_wasm_stdlib::host::{
-    FLOAT_ROUNDING_MODES_TO_NEAREST, cache_ledger_obj, float_add, float_compare, float_divide,
-    float_from_int, float_from_mant_exp, float_from_uint, float_multiply, float_pow, float_root,
-    float_subtract, get_ledger_obj_array_len, get_ledger_obj_field, get_ledger_obj_nested_field,
+    RoundingMode, cache_ledger_obj, float_add, float_compare, float_divide, float_from_int,
+    float_from_mant_exp, float_from_uint, float_multiply, float_pow, float_root, float_subtract,
+    get_ledger_obj_array_len, get_ledger_obj_field, get_ledger_obj_nested_field,
     trace_opaque_float,
 };
+
+const TO_NEAREST: i32 = RoundingMode::ToNearest as i32;
 use xrpl_wasm_stdlib::sfield;
 use xrpl_wasm_stdlib::sfield::{
     Account, AccountTxnID, Balance, Domain, EmailHash, Flags, LedgerEntryType, MessageKey,
@@ -70,7 +72,7 @@ fn test_float_from_wasm() {
     let _ = trace("\n$$$ test_float_from_wasm $$$");
 
     let mut f: [u8; 12] = [0u8; 12];
-    if 12 == unsafe { float_from_int(12300, f.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) } {
+    if 12 == unsafe { float_from_int(12300, f.as_mut_ptr(), 12, TO_NEAREST) } {
         let _ = trace_float("  float from i64 12300:", &f);
         let _ = trace_data("  float from i64 12300 as HEX:", &f, AsHex);
     } else {
@@ -85,7 +87,7 @@ fn test_float_from_wasm() {
                 8,
                 f.as_mut_ptr(),
                 12,
-                FLOAT_ROUNDING_MODES_TO_NEAREST,
+                TO_NEAREST,
             )
         }
     {
@@ -94,11 +96,7 @@ fn test_float_from_wasm() {
         let _ = trace("  float from u64 12300: failed");
     }
 
-    if 12
-        == unsafe {
-            float_from_mant_exp(123, 2, f.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST)
-        }
-    {
+    if 12 == unsafe { float_from_mant_exp(123, 2, f.as_mut_ptr(), 12, TO_NEAREST) } {
         let _ = trace_float("  float from exp 2, mantissa 123:", &f);
     } else {
         let _ = trace("  float from exp 2, mantissa 3: failed");
@@ -112,7 +110,7 @@ fn test_float_compare() {
     let _ = trace("\n$$$ test_float_compare $$$");
 
     let mut f1: [u8; 12] = [0u8; 12];
-    if 12 != unsafe { float_from_int(1, f1.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) } {
+    if 12 != unsafe { float_from_int(1, f1.as_mut_ptr(), 12, TO_NEAREST) } {
         let _ = trace("  float from 1: failed");
     } else {
         let _ = trace_float("  float from 1:", &f1);
@@ -150,13 +148,13 @@ fn test_float_add_subtract() {
                 12,
                 f_compute.as_mut_ptr(),
                 12,
-                FLOAT_ROUNDING_MODES_TO_NEAREST,
+                TO_NEAREST,
             )
         };
         // let _ = trace_float("  float:", &f_compute);
     }
     let mut f10: [u8; 12] = [0u8; 12];
-    if 12 != unsafe { float_from_int(10, f10.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) } {
+    if 12 != unsafe { float_from_int(10, f10.as_mut_ptr(), 12, TO_NEAREST) } {
         // let _ = trace("  float from 10: failed");
     }
     if 0 == unsafe { float_compare(f10.as_ptr(), 12, f_compute.as_ptr(), 12) } {
@@ -174,7 +172,7 @@ fn test_float_add_subtract() {
                 12,
                 f_compute.as_mut_ptr(),
                 12,
-                FLOAT_ROUNDING_MODES_TO_NEAREST,
+                TO_NEAREST,
             )
         };
     }
@@ -189,7 +187,7 @@ fn test_float_multiply_divide() {
     let _ = trace("\n$$$ test_float_multiply_divide $$$");
 
     let mut f10: [u8; 12] = [0u8; 12];
-    unsafe { float_from_int(10, f10.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) };
+    unsafe { float_from_int(10, f10.as_mut_ptr(), 12, TO_NEAREST) };
     let mut f_compute: [u8; 12] = FLOAT_ONE;
     for i in 0..6 {
         unsafe {
@@ -200,20 +198,13 @@ fn test_float_multiply_divide() {
                 12,
                 f_compute.as_mut_ptr(),
                 12,
-                FLOAT_ROUNDING_MODES_TO_NEAREST,
+                TO_NEAREST,
             )
         };
         // let _ = trace_float("  float:", &f_compute);
     }
     let mut f1000000: [u8; 12] = [0u8; 12];
-    unsafe {
-        float_from_int(
-            1000000,
-            f1000000.as_mut_ptr(),
-            12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
+    unsafe { float_from_int(1000000, f1000000.as_mut_ptr(), 12, TO_NEAREST) };
 
     if 0 == unsafe { float_compare(f1000000.as_ptr(), 12, f_compute.as_ptr(), 12) } {
         let _ = trace("  repeated multiply: good");
@@ -230,12 +221,12 @@ fn test_float_multiply_divide() {
                 12,
                 f_compute.as_mut_ptr(),
                 12,
-                FLOAT_ROUNDING_MODES_TO_NEAREST,
+                TO_NEAREST,
             )
         };
     }
     let mut f01: [u8; 12] = [0u8; 12];
-    unsafe { float_from_mant_exp(1, -1, f01.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) };
+    unsafe { float_from_mant_exp(1, -1, f01.as_mut_ptr(), 12, TO_NEAREST) };
 
     if 0 == unsafe { float_compare(f_compute.as_ptr(), 12, f01.as_ptr(), 12) } {
         let _ = trace("  repeated divide: good");
@@ -255,7 +246,7 @@ fn test_float_pow() {
             3,
             f_compute.as_mut_ptr(),
             12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
+            TO_NEAREST,
         )
     };
     let _ = trace_float("  float cube of 1:", &f_compute);
@@ -267,61 +258,25 @@ fn test_float_pow() {
             6,
             f_compute.as_mut_ptr(),
             12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
+            TO_NEAREST,
         )
     };
     let _ = trace_float("  float 6th power of -1:", &f_compute);
 
     let mut f9: [u8; 12] = [0u8; 12];
-    unsafe { float_from_int(9, f9.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) };
-    unsafe {
-        float_pow(
-            f9.as_ptr(),
-            12,
-            2,
-            f_compute.as_mut_ptr(),
-            12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
+    unsafe { float_from_int(9, f9.as_mut_ptr(), 12, TO_NEAREST) };
+    unsafe { float_pow(f9.as_ptr(), 12, 2, f_compute.as_mut_ptr(), 12, TO_NEAREST) };
     let _ = trace_float("  float square of 9:", &f_compute);
 
-    unsafe {
-        float_pow(
-            f9.as_ptr(),
-            12,
-            0,
-            f_compute.as_mut_ptr(),
-            12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
+    unsafe { float_pow(f9.as_ptr(), 12, 0, f_compute.as_mut_ptr(), 12, TO_NEAREST) };
     let _ = trace_float("  float 0th power of 9:", &f_compute);
 
     let mut f0: [u8; 12] = [0u8; 12];
-    unsafe { float_from_int(0, f0.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) };
-    unsafe {
-        float_pow(
-            f0.as_ptr(),
-            12,
-            2,
-            f_compute.as_mut_ptr(),
-            12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
+    unsafe { float_from_int(0, f0.as_mut_ptr(), 12, TO_NEAREST) };
+    unsafe { float_pow(f0.as_ptr(), 12, 2, f_compute.as_mut_ptr(), 12, TO_NEAREST) };
     let _ = trace_float("  float square of 0:", &f_compute);
 
-    let r = unsafe {
-        float_pow(
-            f0.as_ptr(),
-            12,
-            0,
-            f_compute.as_mut_ptr(),
-            12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
+    let r = unsafe { float_pow(f0.as_ptr(), 12, 0, f_compute.as_mut_ptr(), 12, TO_NEAREST) };
     let _ = trace_num(
         "  float 0th power of 0 (expecting INVALID_PARAMS error):",
         r as i64,
@@ -332,40 +287,15 @@ fn test_float_root() {
     let _ = trace("\n$$$ test_float_root $$$");
 
     let mut f9: [u8; 12] = [0u8; 12];
-    unsafe { float_from_int(9, f9.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) };
+    unsafe { float_from_int(9, f9.as_mut_ptr(), 12, TO_NEAREST) };
     let mut f_compute: [u8; 12] = [0u8; 12];
-    unsafe {
-        float_root(
-            f9.as_ptr(),
-            12,
-            2,
-            f_compute.as_mut_ptr(),
-            12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
+    unsafe { float_root(f9.as_ptr(), 12, 2, f_compute.as_mut_ptr(), 12, TO_NEAREST) };
     let _ = trace_float("  float sqrt of 9:", &f_compute);
-    unsafe {
-        float_root(
-            f9.as_ptr(),
-            12,
-            3,
-            f_compute.as_mut_ptr(),
-            12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
+    unsafe { float_root(f9.as_ptr(), 12, 3, f_compute.as_mut_ptr(), 12, TO_NEAREST) };
     let _ = trace_float("  float cbrt of 9:", &f_compute);
 
     let mut f1000000: [u8; 12] = [0u8; 12];
-    unsafe {
-        float_from_int(
-            1000000,
-            f1000000.as_mut_ptr(),
-            12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
-        )
-    };
+    unsafe { float_from_int(1000000, f1000000.as_mut_ptr(), 12, TO_NEAREST) };
     unsafe {
         float_root(
             f1000000.as_ptr(),
@@ -373,7 +303,7 @@ fn test_float_root() {
             3,
             f_compute.as_mut_ptr(),
             12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
+            TO_NEAREST,
         )
     };
     let _ = trace_float("  float cbrt of 1000000:", &f_compute);
@@ -384,7 +314,7 @@ fn test_float_root() {
             6,
             f_compute.as_mut_ptr(),
             12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
+            TO_NEAREST,
         )
     };
     let _ = trace_float("  float 6th root of 1000000:", &f_compute);
@@ -402,7 +332,7 @@ fn test_float_negate() {
             12,
             f_compute.as_mut_ptr(),
             12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
+            TO_NEAREST,
         )
     };
     // let _ = trace_float("  float:", &f_compute);
@@ -420,7 +350,7 @@ fn test_float_negate() {
             12,
             f_compute.as_mut_ptr(),
             12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
+            TO_NEAREST,
         )
     };
     // let _ = trace_float("  float:", &f_compute);
@@ -436,7 +366,7 @@ fn test_float_invert() {
 
     let mut f_compute: [u8; 12] = [0u8; 12];
     let mut f10: [u8; 12] = [0u8; 12];
-    unsafe { float_from_int(10, f10.as_mut_ptr(), 12, FLOAT_ROUNDING_MODES_TO_NEAREST) };
+    unsafe { float_from_int(10, f10.as_mut_ptr(), 12, TO_NEAREST) };
     unsafe {
         float_divide(
             FLOAT_ONE.as_ptr(),
@@ -445,7 +375,7 @@ fn test_float_invert() {
             12,
             f_compute.as_mut_ptr(),
             12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
+            TO_NEAREST,
         )
     };
     let _ = trace_float("  invert a float from 10:", &f_compute);
@@ -457,7 +387,7 @@ fn test_float_invert() {
             12,
             f_compute.as_mut_ptr(),
             12,
-            FLOAT_ROUNDING_MODES_TO_NEAREST,
+            TO_NEAREST,
         )
     };
     let _ = trace_float("  invert again:", &f_compute);

--- a/e2e-tests/host_functions_test/src/lib.rs
+++ b/e2e-tests/host_functions_test/src/lib.rs
@@ -31,7 +31,6 @@ use xrpl_wasm_stdlib::core::types::account_id::AccountID;
 use xrpl_wasm_stdlib::core::types::amount::Amount;
 use xrpl_wasm_stdlib::core::types::currency::Currency;
 use xrpl_wasm_stdlib::core::types::mpt_id::MptId;
-use xrpl_wasm_stdlib::core::types::xfloat::XFloat;
 use xrpl_wasm_stdlib::host;
 use xrpl_wasm_stdlib::host::trace::{
     DataRepr, trace, trace_account_buf, trace_amount, trace_data, trace_num,
@@ -909,26 +908,23 @@ fn test_trace_amount_functions() -> i32 {
     currency_bytes[12..15].copy_from_slice(b"USD");
     let issuer_bytes = [3u8; 20]; // Test issuer
 
-    // Create a valid IOU amount: $5 USD
-    // Mantissa = 5000000000000000, Exponent = -15 (raw exponent = 82)
-    // Actual value = 5000000000000000 × 10^-15 = 5
-    // Format: [Type=1][Sign=1][Exponent=82][Mantissa=54bits]
-    // Type bit (bit 63) = 1, Sign bit (bit 62) = 1
-    // Exponent 82 = 0b01010010
-    // Top byte: 0b11010100 = 0xD4
-    // Second byte: 0b10010001 = 0x91
-    let amount_bytes = [
-        0xD4, 0x91, 0xC3, 0x79, 0x37, 0xE0, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
-    ]; // Valid IOU: $5 USD (12-byte XFloat: first 8 bytes are STAmount wire format, trailing 4 zero-pad)
-
     let currency = Currency::from(currency_bytes);
     let issuer = AccountID::from(issuer_bytes);
-    let amount = XFloat(amount_bytes);
 
-    let iou_amount = Amount::IOU {
-        amount,
+    // Create a valid IOU amount: $5 USD
+    // Mantissa = 5000000000000000, Exponent = -15 (actual value = 5)
+    let iou_amount = match Amount::iou_from_mant_exp(
+        5_000_000_000_000_000,
+        -15,
         issuer,
         currency,
+        host::RoundingMode::ToNearest,
+    ) {
+        host::Result::Ok(a) => a,
+        host::Result::Err(e) => {
+            let _ = trace_num("ERROR: iou_from_mant_exp failed:", e.code() as i64);
+            return -610;
+        }
     };
     let trace_result = trace_amount("Test IOU amount", &iou_amount);
     match trace_result {

--- a/xrpl-wasm-stdlib/src/core/ledger_objects/mod.rs
+++ b/xrpl-wasm-stdlib/src/core/ledger_objects/mod.rs
@@ -946,35 +946,32 @@ pub mod ledger_object {
 
         #[test]
         fn test_amount_decodes_iou_variant() {
+            // IOU amount bytes: byte0 bit7=1 (IOU type), rest are arbitrary mantissa/exponent data
+            const AMOUNT_BYTES: [u8; 8] = [0x80, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+
             let mut mock = MockHostBindings::new();
             mock.expect_get_current_ledger_obj_field()
                 .with(eq::<i32>(sfield::Amount.into()), always(), eq(48))
                 .times(1)
                 .returning(|_, buf, size| {
-                    // IOU: byte0 bit7=1; bytes[0..8]=XFloat (opaque, content
-                    // doesn't matter for variant detection), bytes[8..28]=currency,
-                    // bytes[28..48]=issuer.
+                    // IOU STAmount layout: bytes[0..8]=8-byte float, bytes[8..28]=currency, bytes[28..48]=issuer
                     let slice = unsafe { core::slice::from_raw_parts_mut(buf, size) };
                     slice.fill(0);
-                    slice[0] = 0x80;
+                    slice[0..8].copy_from_slice(&AMOUNT_BYTES);
                     slice[8..28].fill(0xCC);
                     slice[28..48].fill(0xDD);
                     48
                 });
-            mock.expect_float_from_stamount().times(1).returning(
-                |_, _, out_buff, out_buff_len, _| {
-                    unsafe { out_buff.copy_from_nonoverlapping([0u8; 12].as_ptr(), 12) }
-                    out_buff_len as i32
-                },
-            );
-
             let _guard = setup_mock(mock);
 
             let amount = Amount::get_from_current_ledger_obj(sfield::Amount.into()).unwrap();
             match amount {
                 Amount::IOU {
-                    issuer, currency, ..
+                    amount,
+                    issuer,
+                    currency,
                 } => {
+                    assert_eq!(amount, AMOUNT_BYTES);
                     assert_eq!(issuer, AccountID::from([0xDD; 20]));
                     assert_eq!(currency, Currency::from([0xCC; 20]));
                 }

--- a/xrpl-wasm-stdlib/src/core/types/amount.rs
+++ b/xrpl-wasm-stdlib/src/core/types/amount.rs
@@ -97,7 +97,7 @@ pub enum Amount {
     },
     IOU {
         // amount: Amount::IOU,
-        amount: XFloat, // TODO: Make a helper to detect sign from 2nd bit (trait?)
+        amount: [u8; 8],
         issuer: AccountID,
         currency: Currency,
     },
@@ -168,7 +168,7 @@ impl Amount {
                 currency,
             } => {
                 // IOU format for tracing: opaque float + currency + issuer
-                bytes[0..8].copy_from_slice(&amount.0[..8]);
+                bytes[0..8].copy_from_slice(amount);
                 bytes[8..28].copy_from_slice(currency.as_bytes());
                 bytes[28..48].copy_from_slice(&issuer.0);
                 // No padding needed - uses all 48 bytes
@@ -176,6 +176,43 @@ impl Amount {
         }
 
         (bytes, AMOUNT_SIZE)
+    }
+
+    /// Converts this `Amount` to an `XFloat` via the host's `float_from_stamount` function.
+    pub fn to_xfloat(&self, rounding_mode: host::RoundingMode) -> Result<XFloat> {
+        let (stamount_bytes, len) = self.to_stamount_bytes();
+        let mut float_out = [0u8; 12];
+        let rescode = unsafe {
+            host::float_from_stamount(
+                stamount_bytes.as_ptr(),
+                len,
+                float_out.as_mut_ptr(),
+                12,
+                rounding_mode.into(),
+            )
+        };
+        host::error_codes::match_result_code_with_expected_bytes(rescode, 12, || XFloat(float_out))
+    }
+
+    /// Creates an `Amount::IOU` from a mantissa and exponent.
+    ///
+    /// `rounding_mode` is forwarded to the host.
+    pub fn iou_from_mant_exp(
+        mantissa: i64,
+        exponent: i32,
+        issuer: AccountID,
+        currency: Currency,
+        rounding_mode: host::RoundingMode,
+    ) -> Result<Self> {
+        XFloat::from_mant_exp(mantissa, exponent, rounding_mode).map(|xfloat| {
+            let mut amount = [0u8; 8];
+            amount.copy_from_slice(&xfloat.0[0..8]);
+            Amount::IOU {
+                amount,
+                issuer,
+                currency,
+            }
+        })
     }
 
     /// Parses a Amount from a byte array.
@@ -203,8 +240,9 @@ impl Amount {
         let is_positive: bool = byte0 & 0x40 == 0x40; // Bit 6
 
         if is_xrp_or_mpt {
+            // XRP STAmount: [0/type][0/sign][6/reserved][64/value]
             if is_xrp {
-                // If we get here, we'll have 8 bytes.
+                // If we get here, we'll have 8 bytes (type/sign/reserved stripped off)
                 let mut amount_bytes = [0u8; 8];
                 amount_bytes.copy_from_slice(&bytes[0..8]);
 
@@ -222,9 +260,9 @@ impl Amount {
                 Ok(amount)
             }
             // is_mpt
+            // MPT STAmount: [0/type][1/sign][1/is-mpt][5/reserved][64/value]
             else {
-                // If we get here, we'll have 33 bytes.
-                // MPT amount: [0/type][1/sign][1/is-mpt][5/reserved][64/value]
+                // If we get here, we'll have 33 bytes (type/sign/reserved stripped off)
                 let mut num_units_bytes = [0u8; 8];
                 // Skip the first MPT byte, which is control bytes. Grab the next 8 for the u64
                 num_units_bytes.copy_from_slice(&bytes[1..9]);
@@ -246,32 +284,9 @@ impl Amount {
         }
         // is_iou
         else {
-            // If we get here, we'll have 48 bytes.
-
-            // IOU amount: [1/type][1/sign][8/exponent][54/mantissa]
-            let opaque_float_amount_bytes: [u8; 8] = bytes[0..8].try_into().unwrap();
-            let mut float_out = [0u8; 12];
-            let rescode = unsafe {
-                crate::host::float_from_stamount(
-                    opaque_float_amount_bytes.as_ptr(),
-                    8,
-                    float_out.as_mut_ptr(),
-                    12,
-                    0,
-                )
-            };
-            let opaque_float = match crate::host::error_codes::match_result_code_with_expected_bytes(
-                rescode,
-                12,
-                || XFloat(float_out),
-            ) {
-                Ok(f) => f,
-                Err(e) => return Err(e),
-            };
-
-            // Parse the Amount::IOU from the first 9 bytes
-            // let mut amount_bytes = [0u8; 9];
-            // amount_bytes.copy_from_slice(&bytes[0..9]);
+            // IOU STAmount: [1/type][1/sign][6/reserved][64/amount][160/currency][160/issuer]
+            // If we get here, we'll have 48 bytes (type/sign/reserved stripped off)
+            let amount: [u8; 8] = bytes[0..8].try_into().unwrap();
 
             // Parse the Currency from the next 20 bytes
             let mut currency_bytes = [0u8; 20];
@@ -284,7 +299,7 @@ impl Amount {
             let issuer = AccountID::from(issuer_bytes);
 
             let amount = Amount::IOU {
-                amount: opaque_float,
+                amount,
                 issuer,
                 currency,
             };
@@ -448,15 +463,6 @@ mod tests {
 
     #[test]
     fn test_parse_iou_amount() {
-        let mut mock = MockHostBindings::new();
-        mock.expect_float_from_stamount()
-            .times(1)
-            .returning(|_, _, out_buff, out_buff_len, _| {
-                unsafe { out_buff.copy_from_nonoverlapping([0xCCu8; 12].as_ptr(), 12) }
-                out_buff_len as i32
-            });
-        let _guard = setup_mock(mock);
-
         // IOU with exponent = 5, mantissa = 12345
         const EXPONENT: u8 = 5; // 1 byte
         const MANTISSA: u64 = 12345; // 57 bits (so need or 8 bytes)
@@ -521,7 +527,7 @@ mod tests {
                 issuer,
                 currency,
             } => {
-                assert_eq!(amount, XFloat([0xCC; 12]));
+                assert_eq!(amount, eight_input_bytes);
                 assert_eq!(issuer, AccountID::from(ISSUER_BYTES));
                 assert_eq!(currency, Currency::from(CURRENCY_BYTES));
             }
@@ -678,44 +684,35 @@ mod tests {
 
     #[test]
     fn test_round_trip_iou_positive() {
-        let mut mock = MockHostBindings::new();
-        mock.expect_float_from_stamount()
-            .times(1)
-            .returning(|_, _, out_buff, out_buff_len, _| {
-                unsafe { out_buff.copy_from_nonoverlapping([0xBBu8; 12].as_ptr(), 12) }
-                out_buff_len as i32
-            });
-        let _guard = setup_mock(mock);
-
         // Test positive IOU amount
         const EXPONENT: u8 = 7;
         const MANTISSA: u64 = 98765;
         const CURRENCY_BYTES: [u8; 20] = [0xEF; 20];
         const ISSUER_BYTES: [u8; 20] = [0x12; 20];
 
-        // Create the XFloat bytes manually
+        // Create the IOU.amount bytes manually
         // IOU format: [1/type][1/sign][8/exponent][54/mantissa]
-        let mut opaque_float_bytes = [0u8; 8];
+        let mut iou_amount_bytes = [0u8; 8];
 
         // First byte: IOU positive flag (0xC0) with exponent bits
-        opaque_float_bytes[0] = 0xC0 | ((EXPONENT >> 2) & 0x3F);
+        iou_amount_bytes[0] = 0xC0 | ((EXPONENT >> 2) & 0x3F);
 
         // Second byte: first 2 bits for exponent, rest will be part of mantissa
-        opaque_float_bytes[1] = (EXPONENT & 0x03) << 6;
+        iou_amount_bytes[1] = (EXPONENT & 0x03) << 6;
 
         let mantissa_bytes = MANTISSA.to_be_bytes();
 
         // Copy the mantissa bytes, preserving the exponent bits in opaque_float_bytes[1]
-        opaque_float_bytes[1] |= mantissa_bytes[0] & 0x3F;
-        opaque_float_bytes[2] = mantissa_bytes[1];
-        opaque_float_bytes[3] = mantissa_bytes[2];
-        opaque_float_bytes[4] = mantissa_bytes[3];
-        opaque_float_bytes[5] = mantissa_bytes[4];
-        opaque_float_bytes[6] = mantissa_bytes[5];
-        opaque_float_bytes[7] = mantissa_bytes[6];
+        iou_amount_bytes[1] |= mantissa_bytes[0] & 0x3F;
+        iou_amount_bytes[2] = mantissa_bytes[1];
+        iou_amount_bytes[3] = mantissa_bytes[2];
+        iou_amount_bytes[4] = mantissa_bytes[3];
+        iou_amount_bytes[5] = mantissa_bytes[4];
+        iou_amount_bytes[6] = mantissa_bytes[5];
+        iou_amount_bytes[7] = mantissa_bytes[6];
 
         let original = Amount::IOU {
-            amount: XFloat([0xBB; 12]),
+            amount: iou_amount_bytes,
             issuer: AccountID::from(ISSUER_BYTES),
             currency: Currency::from(CURRENCY_BYTES),
         };
@@ -723,19 +720,18 @@ mod tests {
         // Create the expected byte layout for IOU
         // IOU format: [1/type][1/sign][8/exponent][54/mantissa][160/currency][160/issuer]
         let mut expected_bytes = [0u8; 48];
-        expected_bytes[0..8].copy_from_slice(&opaque_float_bytes);
+        expected_bytes[0..8].copy_from_slice(&iou_amount_bytes);
         expected_bytes[8..28].copy_from_slice(&CURRENCY_BYTES);
         expected_bytes[28..48].copy_from_slice(&ISSUER_BYTES);
 
         // Test from_bytes -> to_bytes round trip
-        // (float_from_stamount converts 8-byte STAmount to 12-byte STNumber via mock)
         let parsed = Amount::from_bytes(&expected_bytes).unwrap();
         assert_eq!(parsed, original);
 
-        // Test to_stamount_bytes format (first 8 bytes of the 12-byte STNumber float)
+        // Test to_stamount_bytes format
         let (stamount_bytes, len) = original.to_stamount_bytes();
         assert_eq!(len, 48);
-        assert_eq!(&stamount_bytes[0..8], &[0xBBu8; 8]); // First 8 bytes of STNumber
+        assert_eq!(&stamount_bytes[0..8], &iou_amount_bytes); // Raw 8-byte STAmount float
         assert_eq!(&stamount_bytes[8..28], &CURRENCY_BYTES); // Currency
         assert_eq!(&stamount_bytes[28..48], &ISSUER_BYTES); // Issuer
         // No padding for IOU - uses all 48 bytes
@@ -743,44 +739,35 @@ mod tests {
 
     #[test]
     fn test_round_trip_iou_negative() {
-        let mut mock = MockHostBindings::new();
-        mock.expect_float_from_stamount()
-            .times(1)
-            .returning(|_, _, out_buff, out_buff_len, _| {
-                unsafe { out_buff.copy_from_nonoverlapping([0xAAu8; 12].as_ptr(), 12) }
-                out_buff_len as i32
-            });
-        let _guard = setup_mock(mock);
-
         // Test negative IOU amount
         const EXPONENT: u8 = 3;
         const MANTISSA: u64 = 12345;
         const CURRENCY_BYTES: [u8; 20] = [0x34; 20];
         const ISSUER_BYTES: [u8; 20] = [0x56; 20];
 
-        // Create the XFloat bytes manually for negative amount
+        // Create the IOU.amount bytes manually for negative amount
         // IOU format: [1/type][0/sign][8/exponent][54/mantissa]
-        let mut opaque_float_bytes = [0u8; 8];
+        let mut iou_amount_bytes = [0u8; 8];
 
         // First byte: IOU negative flag (0x80) with exponent bits
-        opaque_float_bytes[0] = 0x80 | ((EXPONENT >> 2) & 0x3F);
+        iou_amount_bytes[0] = 0x80 | ((EXPONENT >> 2) & 0x3F);
 
         // Second byte: first 2 bits for exponent, rest will be part of mantissa
-        opaque_float_bytes[1] = (EXPONENT & 0x03) << 6;
+        iou_amount_bytes[1] = (EXPONENT & 0x03) << 6;
 
         let mantissa_bytes = MANTISSA.to_be_bytes();
 
-        // Copy the mantissa bytes, preserving the exponent bits in opaque_float_bytes[1]
-        opaque_float_bytes[1] |= mantissa_bytes[0] & 0x3F;
-        opaque_float_bytes[2] = mantissa_bytes[1];
-        opaque_float_bytes[3] = mantissa_bytes[2];
-        opaque_float_bytes[4] = mantissa_bytes[3];
-        opaque_float_bytes[5] = mantissa_bytes[4];
-        opaque_float_bytes[6] = mantissa_bytes[5];
-        opaque_float_bytes[7] = mantissa_bytes[6];
+        // Copy the mantissa bytes, preserving the exponent bits in iou_amount_bytes[1]
+        iou_amount_bytes[1] |= mantissa_bytes[0] & 0x3F;
+        iou_amount_bytes[2] = mantissa_bytes[1];
+        iou_amount_bytes[3] = mantissa_bytes[2];
+        iou_amount_bytes[4] = mantissa_bytes[3];
+        iou_amount_bytes[5] = mantissa_bytes[4];
+        iou_amount_bytes[6] = mantissa_bytes[5];
+        iou_amount_bytes[7] = mantissa_bytes[6];
 
         let original = Amount::IOU {
-            amount: XFloat([0xAA; 12]),
+            amount: iou_amount_bytes,
             issuer: AccountID::from(ISSUER_BYTES),
             currency: Currency::from(CURRENCY_BYTES),
         };
@@ -788,19 +775,18 @@ mod tests {
         // Create the expected byte layout for negative IOU
         // IOU format: [1/type][0/sign][8/exponent][54/mantissa][160/currency][160/issuer]
         let mut expected_bytes = [0u8; 48];
-        expected_bytes[0..8].copy_from_slice(&opaque_float_bytes);
+        expected_bytes[0..8].copy_from_slice(&iou_amount_bytes);
         expected_bytes[8..28].copy_from_slice(&CURRENCY_BYTES);
         expected_bytes[28..48].copy_from_slice(&ISSUER_BYTES);
 
         // Test from_bytes -> to_bytes round trip
-        // (float_from_stamount converts 8-byte STAmount to 12-byte STNumber via mock)
         let parsed = Amount::from_bytes(&expected_bytes).unwrap();
         assert_eq!(parsed, original);
 
-        // Test to_stamount_bytes format (first 8 bytes of the 12-byte STNumber float)
+        // Test to_stamount_bytes format
         let (stamount_bytes, len) = original.to_stamount_bytes();
         assert_eq!(len, 48);
-        assert_eq!(&stamount_bytes[0..8], &[0xAAu8; 8]); // First 8 bytes of STNumber
+        assert_eq!(&stamount_bytes[0..8], &iou_amount_bytes); // Raw 8-byte STAmount float
         assert_eq!(&stamount_bytes[8..28], &CURRENCY_BYTES); // Currency
         assert_eq!(&stamount_bytes[28..48], &ISSUER_BYTES); // Issuer
         // No padding for IOU - uses all 48 bytes
@@ -858,5 +844,139 @@ mod tests {
 
         let parsed_large_xrp = Amount::from_bytes(&large_xrp_bytes).unwrap();
         assert_eq!(parsed_large_xrp, large_xrp);
+    }
+
+    #[test]
+    fn test_to_xfloat_xrp() {
+        let expected = XFloat([0xAA; 12]);
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_stamount()
+            .times(1)
+            .returning(|_, _, out_buff, out_buff_len, _| {
+                unsafe { out_buff.copy_from_nonoverlapping([0xAAu8; 12].as_ptr(), 12) }
+                out_buff_len as i32
+            });
+        let _guard = setup_mock(mock);
+
+        let amount = Amount::XRP {
+            num_drops: 1_000_000,
+        };
+        let result = amount.to_xfloat(host::RoundingMode::ToNearest).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_to_xfloat_iou() {
+        let expected = XFloat([0xBB; 12]);
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_stamount()
+            .times(1)
+            .returning(|_, _, out_buff, out_buff_len, _| {
+                unsafe { out_buff.copy_from_nonoverlapping([0xBBu8; 12].as_ptr(), 12) }
+                out_buff_len as i32
+            });
+        let _guard = setup_mock(mock);
+
+        let amount = Amount::IOU {
+            amount: [0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39],
+            issuer: AccountID::from([0x11; 20]),
+            currency: Currency::from([0x22; 20]),
+        };
+        let result = amount.to_xfloat(host::RoundingMode::ToNearest).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_to_xfloat_mpt() {
+        let expected = XFloat([0xCC; 12]);
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_stamount()
+            .times(1)
+            .returning(|_, _, out_buff, out_buff_len, _| {
+                unsafe { out_buff.copy_from_nonoverlapping([0xCCu8; 12].as_ptr(), 12) }
+                out_buff_len as i32
+            });
+        let _guard = setup_mock(mock);
+
+        let issuer = AccountID::from([0x33; 20]);
+        let mpt_id = MptId::new(42, issuer);
+        let amount = Amount::MPT {
+            num_units: 500_000,
+            is_positive: true,
+            mpt_id,
+        };
+        let result = amount.to_xfloat(host::RoundingMode::ToNearest).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_to_xfloat_host_error() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_stamount()
+            .times(1)
+            .returning(|_, _, _, _, _| -19); // INVALID_FLOAT_INPUT
+        let _guard = setup_mock(mock);
+
+        let amount = Amount::XRP { num_drops: 0 };
+        assert!(amount.to_xfloat(host::RoundingMode::ToNearest).is_err());
+    }
+
+    #[test]
+    fn test_iou_from_mant_exp_success() {
+        const EXPECTED_AMOUNT: [u8; 8] = [0xD4, 0x91, 0xC3, 0x79, 0x37, 0xE0, 0x80, 0x00];
+        const XFLOAT_BYTES: [u8; 12] = [
+            0xD4, 0x91, 0xC3, 0x79, 0x37, 0xE0, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        const ISSUER_BYTES: [u8; 20] = [0x33; 20];
+        const CURRENCY_BYTES: [u8; 20] = [0x44; 20];
+
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_mant_exp()
+            .times(1)
+            .returning(|_, _, out_buff, out_buff_len, _| {
+                unsafe { out_buff.copy_from_nonoverlapping(XFLOAT_BYTES.as_ptr(), 12) }
+                out_buff_len as i32
+            });
+        let _guard = setup_mock(mock);
+
+        let issuer = AccountID::from(ISSUER_BYTES);
+        let currency = Currency::from(CURRENCY_BYTES);
+        let result = Amount::iou_from_mant_exp(
+            5_000_000_000_000_000,
+            -15,
+            issuer,
+            currency,
+            host::RoundingMode::ToNearest,
+        )
+        .unwrap();
+
+        match result {
+            Amount::IOU {
+                amount,
+                issuer: i,
+                currency: c,
+            } => {
+                assert_eq!(amount, EXPECTED_AMOUNT);
+                assert_eq!(i, AccountID::from(ISSUER_BYTES));
+                assert_eq!(c, Currency::from(CURRENCY_BYTES));
+            }
+            _ => panic!("Expected Amount::IOU"),
+        }
+    }
+
+    #[test]
+    fn test_iou_from_mant_exp_host_error() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_mant_exp()
+            .times(1)
+            .returning(|_, _, _, _, _| -19); // INVALID_FLOAT_INPUT
+        let _guard = setup_mock(mock);
+
+        let issuer = AccountID::from([0x01; 20]);
+        let currency = Currency::from([0x02; 20]);
+        assert!(
+            Amount::iou_from_mant_exp(0, 0, issuer, currency, host::RoundingMode::ToNearest)
+                .is_err()
+        );
     }
 }

--- a/xrpl-wasm-stdlib/src/core/types/xfloat.rs
+++ b/xrpl-wasm-stdlib/src/core/types/xfloat.rs
@@ -1,130 +1,56 @@
-/// Opaque 96-bit representation of an XRPL fungible token (IOU) amount (STNumber format).
+use crate::host;
+use crate::host::Result;
+use crate::host::RoundingMode;
+
+/// Opaque 96-bit (12-byte) float in rippled's STNumber wire format.
 ///
-/// This struct encapsulates the 12-byte STNumber format used by rippled's host functions.
-/// Layout: 8-byte big-endian int64 mantissa followed by 4-byte big-endian int32 exponent.
+/// Layout: 8-byte big-endian signed int64 mantissa, followed by 4-byte big-endian signed int32
+/// exponent. The value is `mantissa × 10^exponent`. The host normalizes results to the canonical
+/// form (mantissa in the range [10^15, 10^16), or zero for the zero value).
 ///
 /// # Important
 ///
-/// This type is intentionally opaque - arithmetic operations MUST be performed through
-/// host functions (float_add, float_multiply, etc.) which use rippled's Number class
-/// to ensure exact compatibility with XRPL consensus rules.
-///
-/// ## Derived Traits
-///
-/// - `Copy`: Efficient for this 12-byte struct, enabling implicit copying
-/// - `PartialEq, Eq`: Enable comparisons (bitwise comparison only)
-/// - `Debug, Clone`: Standard traits for development and consistency
-///
-/// **Note**: `PartialEq` and `Eq` perform bitwise comparison only. For semantic
-/// comparison of amounts (e.g., handling different representations of zero),
-/// use host functions.
+/// This type is intentionally opaque — arithmetic operations **must** be performed through
+/// host functions (`float_add`, `float_multiply`, etc.) which delegate to rippled's `Number`
+/// class to ensure exact compatibility with XRPL consensus rules. `PartialEq`/`Eq` perform
+/// bitwise comparison only; use `float_compare` for semantic equality (e.g. different
+/// representations of zero).
 ///
 /// # Example
 ///
 /// ```no_run
 /// # use xrpl_wasm_stdlib::core::types::xfloat::XFloat;
-/// // Create from host function
-/// let mut float_bytes = [0u8; 12];
-/// // float_from_int(100, float_bytes.as_mut_ptr(), 12, 0);
-/// let amount = XFloat(float_bytes);
+/// # use xrpl_wasm_stdlib::host::RoundingMode;
+/// // Create the value 5 (= 5 × 10^0) via the host
+/// let five = XFloat::from_mant_exp(5_000_000_000_000_000, -15, RoundingMode::ToNearest);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct XFloat(pub [u8; 12]);
 
 impl XFloat {
-    // /// Accessor for the 8-bit `exponent` component of an `XFloat`.
-    // ///
-    // /// WARNING: Use with caution. In general, `XFloat` should not be deconstructed; prefer
-    // /// host functions instead (e.g., for things like math operations).
-    // pub fn get_exponent(&self) -> u8 {
-    //     // In big-endian form, the exponent is:
-    //     // * Last 6 bits from bytes[0] (shifted to make room for the 2 bits from bytes[1])
-    //     // * First 2 bits from bytes[1] (shifted down to the lowest position)
-    //     let exponent: u8 = ((self.0[0] & 0x3F) << 2) | ((self.0[1] & 0xC0) >> 6);
-    //
-    //     exponent
-    // }
-    //
-    // /// Accessor for the 54-bit `mantissa` of an `XFloat`.
-    // ///
-    // /// WARNING: Use with caution. In general, `XFloat` should not be deconstructed; prefer
-    // /// host functions instead (e.g., for things like math operations).
-    // pub fn get_mantissa(&self) -> u64 {
-    //     // Extract the 54-bit mantissa from the remaining bytes.
-    //     // The mantissa starts from the last 6 bits of the second byte and continues through the
-    //     // remaining bytes.
-    //
-    //     // Extract the top 6 bits from the second byte (after the 2 exponent bits)
-    //     let top_6_bits = (self[1] & 0x3F) as u64;
-    //
-    //     // Extract the remaining 48 bits from self 2-7
-    //     let next_8_bits = (self[2] as u64) << 40;
-    //     let next_16_bits = (self[3] as u64) << 32;
-    //     let next_24_bits = (self[4] as u64) << 24;
-    //     let next_32_bits = (self[5] as u64) << 16;
-    //     let next_40_bits = (self[6] as u64) << 8;
-    //     let next_48_bits = self[7] as u64;
-    //
-    //     // Combine all the bits to form the 54-bit mantissa
-    //     let mantissa = (top_6_bits << 48)
-    //         | next_8_bits
-    //         | next_16_bits
-    //         | next_24_bits
-    //         | next_32_bits
-    //         | next_40_bits
-    //         | next_48_bits;
-    //
-    //     mantissa
-    // }
-    //
-    //     /// Create a new `XFloat` from an exponent and mantissa.
-    //     ///
-    //     /// WARNING: Use with caution. In general, `XFloat` should be constructed using
-    //     /// host functions instead of manually setting the exponent and mantissa.
-    //     ///
-    //     /// # Arguments
-    //     ///
-    //     /// * `exponent` - An 8-bit exponent value
-    //     /// * `mantissa` - A 54-bit mantissa value
-    //     ///
-    //     /// # Panics
-    //     ///
-    //     /// Panics if the mantissa exceeds 54 bits.
-    //     pub fn from_exponent_and_mantissa(exponent: u8, mantissa: u64) -> Self {
-    //         // Ensure the mantissa fits in 54 bits
-    //         if mantissa > 0x003FFFFFFFFFFFFF {
-    //             panic!("Mantissa exceeds 54 bits");
-    //         }
-    //
-    //         // Create a buffer for the combined value
-    //         let mut bytes = [0u8; 8];
-    //
-    //         // Store the first 6 bits of the exponent in the first byte
-    //         bytes[0] = (exponent >> 2) & 0x3F;
-    //
-    //         // Store the last 2 bits of the exponent in the first 2 bits of the second byte
-    //         bytes[1] = (exponent & 0x03) << 6;
-    //
-    //         // We need to shift the mantissa to align with our byte layout
-    //         // The mantissa is 54 bits, which is 6 bits in the first byte and 48 bits in the remaining 6 bytes
-    //
-    //         // First, handle the top 6 bits that go into the second byte (after the 2 exponent bits)
-    //         bytes[1] |= ((mantissa >> 48) & 0x3F) as u8;
-    //
-    //         // Now handle the remaining 48 bits that go into bytes 2-7
-    //         bytes[2] = ((mantissa >> 40) & 0xFF) as u8;
-    //         bytes[3] = ((mantissa >> 32) & 0xFF) as u8;
-    //         bytes[4] = ((mantissa >> 24) & 0xFF) as u8;
-    //         bytes[5] = ((mantissa >> 16) & 0xFF) as u8;
-    //         bytes[6] = ((mantissa >> 8) & 0xFF) as u8;
-    //         bytes[7] = (mantissa & 0xFF) as u8;
-    //
-    //         // Create a new XFloat from the combined bytes
-    //         // ALWAYS use `from_be_bytes` because that's how things are assembled directly above.
-    //         // This will manifest a u64 which will be correct.
-    //         XFloat(u64::from_be_bytes(bytes))
-    //     }
+    /// Creates an `XFloat` from a mantissa and exponent via the host's `float_from_mant_exp`.
+    ///
+    /// Creates an `XFloat` from a mantissa and exponent via the host's `float_from_mant_exp`.
+    ///
+    /// `rounding_mode` controls how the host rounds the result.
+    pub fn from_mant_exp(
+        mantissa: i64,
+        exponent: i32,
+        rounding_mode: RoundingMode,
+    ) -> Result<Self> {
+        let mut float_out = [0u8; 12];
+        let rescode = unsafe {
+            host::float_from_mant_exp(
+                mantissa,
+                exponent,
+                float_out.as_mut_ptr(),
+                12,
+                rounding_mode.into(),
+            )
+        };
+        host::error_codes::match_result_code_with_expected_bytes(rescode, 12, || XFloat(float_out))
+    }
 }
 
 impl From<[u8; 12]> for XFloat {
@@ -133,12 +59,17 @@ impl From<[u8; 12]> for XFloat {
     }
 }
 
-/// The number `1` in STNumber format (mantissa=1000000000000000, exponent=-15).
+/// The value `0` in STNumber format: all bytes zero.
+pub const FLOAT_ZERO: XFloat = XFloat([0u8; 12]);
+
+/// The value `1` in STNumber format (mantissa=1,000,000,000,000,000, exponent=-15).
+/// Verified against rippled via the e2e float_compare test.
 pub const FLOAT_ONE: [u8; 12] = [
     0x0D, 0xE0, 0xB6, 0xB3, 0xA7, 0x64, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xEE,
 ];
 
-/// The number `-1` in STNumber format (mantissa=-1000000000000000, exponent=-15).
+/// The value `-1` in STNumber format (mantissa=-1,000,000,000,000,000, exponent=-15).
+/// Verified against rippled via the e2e float_compare test.
 pub const FLOAT_NEGATIVE_ONE: [u8; 12] = [
     0xF2, 0x1F, 0x49, 0x4C, 0x58, 0x9C, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xEE,
 ];
@@ -146,17 +77,42 @@ pub const FLOAT_NEGATIVE_ONE: [u8; 12] = [
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::host::RoundingMode;
+    use crate::host::host_bindings_trait::MockHostBindings;
+    use crate::host::setup_mock;
 
     #[test]
-    fn test_xfloat_from_one_canonical_bytes() {
-        // float_from_int(1) produces mantissa=1000000000000000, exponent=-15 in STNumber format.
-        // Verified against rippled via the e2e float_compare test.
-        let one = XFloat::from(FLOAT_ONE);
-        assert_eq!(
-            one.0,
-            [
-                0x0D, 0xE0, 0xB6, 0xB3, 0xA7, 0x64, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xEE
-            ]
-        );
+    fn test_from_mant_exp_success() {
+        const XFLOAT_BYTES: [u8; 12] = [
+            0xD4, 0x91, 0xC3, 0x79, 0x37, 0xE0, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_mant_exp()
+            .times(1)
+            .returning(|_, _, out_buff, out_buff_len, _| {
+                unsafe { out_buff.copy_from_nonoverlapping(XFLOAT_BYTES.as_ptr(), 12) }
+                out_buff_len as i32
+            });
+        let _guard = setup_mock(mock);
+
+        let result =
+            XFloat::from_mant_exp(5_000_000_000_000_000, -15, RoundingMode::ToNearest).unwrap();
+        assert_eq!(result, XFloat(XFLOAT_BYTES));
+    }
+
+    #[test]
+    fn test_from_mant_exp_host_error() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_mant_exp()
+            .times(1)
+            .returning(|_, _, _, _, _| -19); // INVALID_FLOAT_INPUT
+        let _guard = setup_mock(mock);
+
+        assert!(XFloat::from_mant_exp(0, 0, RoundingMode::ToNearest).is_err());
+    }
+
+    #[test]
+    fn test_float_zero_is_all_zeros() {
+        assert_eq!(FLOAT_ZERO, XFloat([0u8; 12]));
     }
 }

--- a/xrpl-wasm-stdlib/src/host/mod.rs
+++ b/xrpl-wasm-stdlib/src/host/mod.rs
@@ -23,15 +23,21 @@ pub mod error_codes;
 pub mod field_helpers;
 pub mod trace;
 
-// Float rounding mode constants (same as in host_bindings.rs)
-#[allow(unused)]
-pub const FLOAT_ROUNDING_MODES_TO_NEAREST: i32 = 0;
-#[allow(unused)]
-pub const FLOAT_ROUNDING_MODES_TOWARDS_ZERO: i32 = 1;
-#[allow(unused)]
-pub const FLOAT_ROUNDING_MODES_DOWNWARD: i32 = 2;
-#[allow(unused)]
-pub const FLOAT_ROUNDING_MODES_UPWARD: i32 = 3;
+/// Rounding mode for host float operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum RoundingMode {
+    ToNearest = 0,
+    TowardsZero = 1,
+    Downward = 2,
+    Upward = 3,
+}
+
+impl From<RoundingMode> for i32 {
+    fn from(mode: RoundingMode) -> i32 {
+        mode as i32
+    }
+}
 
 // This setup allows us to keep all host functions in the `host::` namespace, but vary the implementation based on
 // target and build profiles.
@@ -334,5 +340,71 @@ impl Error {
 impl From<Error> for i64 {
     fn from(val: Error) -> Self {
         val as i64
+    }
+}
+
+#[cfg(test)]
+mod rounding_mode_tests {
+    use super::*;
+    use crate::host::host_bindings_trait::MockHostBindings;
+    use crate::host::setup_mock;
+    use mockall::predicate::eq;
+
+    // Verify integer values match rippled's Number::rounding_mode C++ enum:
+    // enum rounding_mode { to_nearest, towards_zero, downward, upward };
+    // (unscoped C++ enum defaults: 0, 1, 2, 3)
+    #[test]
+    fn test_rounding_mode_integer_values() {
+        assert_eq!(RoundingMode::ToNearest as i32, 0);
+        assert_eq!(RoundingMode::TowardsZero as i32, 1);
+        assert_eq!(RoundingMode::Downward as i32, 2);
+        assert_eq!(RoundingMode::Upward as i32, 3);
+    }
+
+    #[test]
+    fn test_rounding_mode_into_i32() {
+        assert_eq!(i32::from(RoundingMode::ToNearest), 0);
+        assert_eq!(i32::from(RoundingMode::TowardsZero), 1);
+        assert_eq!(i32::from(RoundingMode::Downward), 2);
+        assert_eq!(i32::from(RoundingMode::Upward), 3);
+    }
+
+    fn make_mock_expecting_rounding_mode(expected_mode: i32) -> MockHostBindings {
+        let mut mock = MockHostBindings::new();
+        mock.expect_float_from_mant_exp()
+            .with(
+                eq(1i64),
+                eq(0i32),
+                mockall::predicate::always(),
+                mockall::predicate::always(),
+                eq(expected_mode),
+            )
+            .times(1)
+            .returning(|_, _, _, out_buff_len, _| out_buff_len as i32);
+        mock
+    }
+
+    #[test]
+    fn test_rounding_mode_to_nearest_passed_to_host() {
+        let _guard = setup_mock(make_mock_expecting_rounding_mode(0));
+        let _ = crate::core::types::xfloat::XFloat::from_mant_exp(1, 0, RoundingMode::ToNearest);
+    }
+
+    #[test]
+    fn test_rounding_mode_towards_zero_passed_to_host() {
+        let _guard = setup_mock(make_mock_expecting_rounding_mode(1));
+        let _ = crate::core::types::xfloat::XFloat::from_mant_exp(1, 0, RoundingMode::TowardsZero);
+    }
+
+    #[test]
+    fn test_rounding_mode_downward_passed_to_host() {
+        let _guard = setup_mock(make_mock_expecting_rounding_mode(2));
+        let _ = crate::core::types::xfloat::XFloat::from_mant_exp(1, 0, RoundingMode::Downward);
+    }
+
+    #[test]
+    fn test_rounding_mode_upward_passed_to_host() {
+        let _guard = setup_mock(make_mock_expecting_rounding_mode(3));
+        let _ = crate::core::types::xfloat::XFloat::from_mant_exp(1, 0, RoundingMode::Upward);
     }
 }

--- a/xrpl-wasm-stdlib/src/host/trace.rs
+++ b/xrpl-wasm-stdlib/src/host/trace.rs
@@ -212,20 +212,16 @@ mod tests {
         // Create a test IOU Amount
         use crate::core::types::account_id::AccountID;
         use crate::core::types::currency::Currency;
-        use crate::core::types::xfloat::XFloat;
 
         let currency_bytes = [2u8; 20];
         let issuer_bytes = [3u8; 20];
-        let amount_bytes = [
-            0xC0u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39, 0x00, 0x00, 0x00, 0x00,
-        ];
+        let amount_bytes = [0xC0u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39];
 
         let currency = Currency::from(currency_bytes);
         let issuer = AccountID::from(issuer_bytes);
-        let amount = XFloat(amount_bytes);
 
         let amount = Amount::IOU {
-            amount,
+            amount: amount_bytes,
             issuer,
             currency,
         };
@@ -286,22 +282,19 @@ mod tests {
         // Test IOU format
         use crate::core::types::account_id::AccountID;
         use crate::core::types::currency::Currency;
-        use crate::core::types::xfloat::XFloat;
 
         let currency_bytes = [2u8; 20];
         let issuer_bytes = [3u8; 20];
-        let amount_bytes = [
-            0xC0u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39, 0x00, 0x00, 0x00, 0x00,
-        ];
+        let amount_bytes: [u8; 8] = [0xC0u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x39];
 
         let iou_amount = Amount::IOU {
-            amount: XFloat(amount_bytes),
+            amount: amount_bytes,
             issuer: AccountID::from(issuer_bytes),
             currency: Currency::from(currency_bytes),
         };
         let (bytes, len) = iou_amount.to_stamount_bytes();
         assert_eq!(len, 48); // All Amount types should return 48 bytes
-        assert_eq!(&bytes[0..8], &amount_bytes[..8]); // First 8 bytes of the 12-byte STNumber float
+        assert_eq!(&bytes[0..8], &amount_bytes); // Raw 8-byte float amount from the STAmount encoding
 
         // Test MPT format
         use crate::core::types::mpt_id::MptId;


### PR DESCRIPTION
  - Amount IOU field simplification: Amount::IOU.amount changes from OpaqueFloat (a newtype wrapper) to [u8; 8], removing the unnecessary wrapper. Adds Amount::to_xfloat(rounding_mode) and Amount::iou_from_mant_exp(...) helpers for converting between Amount and XFloat via the host.
  - Typed RoundingMode enum: replaces the four raw FLOAT_ROUNDING_MODES_* i32 constants with a #[repr(i32)] enum whose variants map exactly to rippled's Number::rounding_mode C++ enum values (verified by unit tests). All float host calls (XFloat::from_mant_exp, Amount::to_xfloat — now require an explicit RoundingMode argument.)