### PR TITLE
chore: Make dependabot PRs conform to PR naming rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 7
+    commit-message:
+      prefix: "build: [DEPENDABOT] "


### PR DESCRIPTION
## High Level Overview of Change

Title says it all

### Context of Change

Dependabot PRs are failing the `Check PR title / check_title (pull_request)` check

### Type of Change

- [x] Build / CI / tooling change
