### PR TITLE
feat: Crypto host function wrappers

### DIFF
--- a/xrpl-common-stdlib/src/crypto.rs
+++ b/xrpl-common-stdlib/src/crypto.rs
@@ -78,6 +78,18 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "internal invariant violated")]
+    fn test_sha512_half_wrong_byte_count() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_compute_sha512_half()
+            .times(1)
+            .returning(|_, _, _, _| 16); // host returns wrong (non-32) byte count
+        let _guard = setup_mock(mock);
+
+        let _ = sha512_half(b"hello");
+    }
+
+    #[test]
     fn test_sha512_half_oversized() {
         let mut mock = MockHostBindings::new();
         mock.expect_compute_sha512_half()

--- a/xrpl-common-stdlib/src/crypto.rs
+++ b/xrpl-common-stdlib/src/crypto.rs
@@ -25,8 +25,7 @@ pub fn sha512_half(data: &[u8]) -> Result<[u8; 32]> {
 ///
 /// Errors: `InvalidParams` if the key is malformed (not 33 bytes / bad prefix);
 /// `DataFieldTooLarge` if any parameter exceeds 1024 bytes.
-pub fn check_sig(key: &PublicKey, msg: &[u8], sig: &[u8]) -> Result<bool> {
-    // Host arg order is (message, signature, pubkey); the wrapper reorders to (key, msg, sig).
+pub fn check_sig(msg: &[u8], sig: &[u8], key: &PublicKey) -> Result<bool> {
     let rescode = unsafe {
         host::check_sig(
             msg.as_ptr(),
@@ -120,7 +119,7 @@ mod tests {
         let _guard = setup_mock(mock);
 
         let key = PublicKey::from(PUBKEY_BYTES);
-        let result = check_sig(&key, b"message", b"signature");
+        let result = check_sig(b"message", b"signature", &key);
         assert!(result.unwrap());
     }
 
@@ -133,7 +132,7 @@ mod tests {
         let _guard = setup_mock(mock);
 
         let key = PublicKey::from(PUBKEY_BYTES);
-        let result = check_sig(&key, b"message", b"signature");
+        let result = check_sig(b"message", b"signature", &key);
         assert!(!result.unwrap());
     }
 
@@ -146,7 +145,7 @@ mod tests {
         let _guard = setup_mock(mock);
 
         let key = PublicKey::from(PUBKEY_BYTES);
-        let result = check_sig(&key, b"message", b"signature");
+        let result = check_sig(b"message", b"signature", &key);
         assert!(result.is_err());
         assert_eq!(result.err().unwrap().code(), INVALID_PARAMS);
     }
@@ -160,7 +159,7 @@ mod tests {
         let _guard = setup_mock(mock);
 
         let key = PublicKey::from(PUBKEY_BYTES);
-        let result = check_sig(&key, &[0u8; 1025], b"signature");
+        let result = check_sig(&[0u8; 1025], b"signature", &key);
         assert!(result.is_err());
         assert_eq!(result.err().unwrap().code(), DATA_FIELD_TOO_LARGE);
     }
@@ -175,6 +174,6 @@ mod tests {
         let _guard = setup_mock(mock);
 
         let key = PublicKey::from(PUBKEY_BYTES);
-        let _ = check_sig(&key, b"m", b"s");
+        let _ = check_sig(b"m", b"s", &key);
     }
 }

--- a/xrpl-common-stdlib/src/crypto.rs
+++ b/xrpl-common-stdlib/src/crypto.rs
@@ -1,0 +1,154 @@
+use crate::host;
+use crate::host::error_codes::match_result_code_with_expected_bytes;
+use crate::host::{Error, Result};
+use crate::types::public_key::{PUBLIC_KEY_BUFFER_SIZE, PublicKey};
+
+/// SHA-512Half: SHA-512 of `data`, truncated to the first 32 bytes.
+///
+/// `data` may be 0..=1024 bytes (`maxWasmParamLength`); the host returns
+/// `DataFieldTooLarge` for larger input.
+pub fn sha512_half(data: &[u8]) -> Result<[u8; 32]> {
+    let mut out = [0u8; 32];
+    let rescode =
+        unsafe { host::compute_sha512_half(data.as_ptr(), data.len(), out.as_mut_ptr(), 32) };
+    match_result_code_with_expected_bytes(rescode, 32, || out)
+}
+
+/// Verify `sig` over `msg` for public key `key`.
+///
+/// `&PublicKey` (33 bytes) enforces the size constraint at the call site.
+/// - secp256k1 keys (0x02/0x03): the host pre-hashes `msg` with SHA-512Half before ECDSA verify.
+/// - Ed25519 keys (0xED): the host verifies the raw `msg` directly (no pre-hash), stripping the
+///   0xED prefix; a non-canonical signature returns `Ok(false)`.
+///
+/// An empty `msg` or empty `sig` is not an error — the host returns `Ok(false)`.
+///
+/// Errors: `InvalidParams` if the key is malformed (not 33 bytes / bad prefix);
+/// `DataFieldTooLarge` if any parameter exceeds 1024 bytes.
+pub fn check_sig(key: &PublicKey, msg: &[u8], sig: &[u8]) -> Result<bool> {
+    // Host arg order is (message, signature, pubkey); the wrapper reorders to (key, msg, sig).
+    let rescode = unsafe {
+        host::check_sig(
+            msg.as_ptr(),
+            msg.len(),
+            sig.as_ptr(),
+            sig.len(),
+            key.0.as_ptr(),
+            PUBLIC_KEY_BUFFER_SIZE,
+        )
+    };
+    match rescode {
+        0 => Result::Ok(false),
+        1 => Result::Ok(true),
+        _ => Result::Err(Error::from_code(rescode)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::error_codes::{DATA_FIELD_TOO_LARGE, INVALID_PARAMS};
+    use crate::host::host_bindings_trait::MockHostBindings;
+    use crate::host::setup_mock;
+
+    fn write_digest(ptr: *mut u8, fill: u8) {
+        unsafe {
+            for i in 0..32 {
+                *ptr.add(i) = fill;
+            }
+        }
+    }
+
+    // ---- sha512_half ----
+
+    #[test]
+    fn test_sha512_half_success() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_compute_sha512_half()
+            .times(1)
+            .returning(|_data, _dlen, out_ptr, _olen| {
+                write_digest(out_ptr, 0xCD);
+                32
+            });
+        let _guard = setup_mock(mock);
+
+        let result = sha512_half(b"hello world");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), [0xCD; 32]);
+    }
+
+    #[test]
+    fn test_sha512_half_oversized() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_compute_sha512_half()
+            .times(1)
+            .returning(|_, _, _, _| DATA_FIELD_TOO_LARGE);
+        let _guard = setup_mock(mock);
+
+        let result = sha512_half(&[0u8; 1025]);
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().code(), DATA_FIELD_TOO_LARGE);
+    }
+
+    // ---- check_sig ----
+
+    const PUBKEY_BYTES: [u8; PUBLIC_KEY_BUFFER_SIZE] = [
+        0x02, 0xC7, 0x38, 0x7F, 0xFC, 0x25, 0xC1, 0x56, 0xCA, 0x7F, 0x8A, 0x6D, 0x76, 0x0C, 0x8D,
+        0x01, 0xEF, 0x64, 0x2C, 0xEE, 0x9C, 0xE4, 0x68, 0x0C, 0x33, 0xFF, 0xB3, 0xFF, 0x39, 0xAF,
+        0xEC, 0xFE, 0x70,
+    ];
+
+    #[test]
+    fn test_check_sig_valid() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_check_sig()
+            .times(1)
+            .returning(|_, _, _, _, _, _| 1);
+        let _guard = setup_mock(mock);
+
+        let key = PublicKey::from(PUBKEY_BYTES);
+        let result = check_sig(&key, b"message", b"signature");
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_check_sig_invalid() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_check_sig()
+            .times(1)
+            .returning(|_, _, _, _, _, _| 0);
+        let _guard = setup_mock(mock);
+
+        let key = PublicKey::from(PUBKEY_BYTES);
+        let result = check_sig(&key, b"message", b"signature");
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_check_sig_bad_pubkey() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_check_sig()
+            .times(1)
+            .returning(|_, _, _, _, _, _| INVALID_PARAMS);
+        let _guard = setup_mock(mock);
+
+        let key = PublicKey::from(PUBKEY_BYTES);
+        let result = check_sig(&key, b"message", b"signature");
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().code(), INVALID_PARAMS);
+    }
+
+    #[test]
+    fn test_check_sig_oversized() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_check_sig()
+            .times(1)
+            .returning(|_, _, _, _, _, _| DATA_FIELD_TOO_LARGE);
+        let _guard = setup_mock(mock);
+
+        let key = PublicKey::from(PUBKEY_BYTES);
+        let result = check_sig(&key, &[0u8; 1025], b"signature");
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().code(), DATA_FIELD_TOO_LARGE);
+    }
+}

--- a/xrpl-common-stdlib/src/crypto.rs
+++ b/xrpl-common-stdlib/src/crypto.rs
@@ -40,7 +40,8 @@ pub fn check_sig(key: &PublicKey, msg: &[u8], sig: &[u8]) -> Result<bool> {
     match rescode {
         0 => Result::Ok(false),
         1 => Result::Ok(true),
-        _ => Result::Err(Error::from_code(rescode)),
+        code if code < 0 => Result::Err(Error::from_code(code)),
+        code => panic!("internal invariant violated: host returned unexpected value {code}"),
     }
 }
 
@@ -162,5 +163,18 @@ mod tests {
         let result = check_sig(&key, &[0u8; 1025], b"signature");
         assert!(result.is_err());
         assert_eq!(result.err().unwrap().code(), DATA_FIELD_TOO_LARGE);
+    }
+
+    #[test]
+    #[should_panic(expected = "internal invariant violated")]
+    fn test_check_sig_unexpected_positive() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_check_sig()
+            .times(1)
+            .returning(|_, _, _, _, _, _| 2); // host returns 2 — only 0 and 1 are valid
+        let _guard = setup_mock(mock);
+
+        let key = PublicKey::from(PUBKEY_BYTES);
+        let _ = check_sig(&key, b"m", b"s");
     }
 }

--- a/xrpl-common-stdlib/src/lib.rs
+++ b/xrpl-common-stdlib/src/lib.rs
@@ -12,7 +12,7 @@ pub use xrpl_macros::pubkey;
 pub use xrpl_macros::r_address;
 pub use xrpl_macros::smart_contract;
 pub use xrpl_macros::smart_escrow;
-
+pub mod crypto;
 pub mod ctx;
 pub mod current_tx;
 pub mod fields;


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

The PR title must follow the Conventional Commits format:
  <type>: <Description>

The description must start with a capital letter.
Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, release, example.
See CONTRIBUTING.md for details.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

Adds wrappers for host functions:
**`sha512_half` contract** (`HostFuncWrapper.cpp:848`, `HostFuncImpl.cpp:47`):
- Input: variable-length data, 0 to `maxWasmParamLength` (1024) bytes
- Output: 32-byte SHA-512-half hash written to caller-supplied buffer
- Errors: `DataFieldTooLarge (-12)` if input > 1024 bytes

**`check_sig` contract** (`HostFuncImpl.cpp:35`, `PublicKey.cpp:270`, `HostFuncWrapper.cpp:817`):
- Parameters: `message` (0-1024 bytes), `sig` (0-1024 bytes), `pubkey` (0-1024 bytes)
- Returns `1` (valid), `0` (invalid), or negative error code
- `InvalidParams (-15)`: pubkey fails `publicKeyType()` -- not exactly 33 bytes or first byte not in `{0xED, 0x02, 0x03}`
- `DataFieldTooLarge (-12)`: any parameter > 1024 bytes
- `0`: empty message or empty sig is not an error -- verify returns false
- For secp256k1 keys (`0x02`/`0x03`): rippled pre-hashes the message with sha512Half before ECDSA verify
- For Ed25519 keys (`0xED`): rippled verifies directly on the raw message (no pre-hash); strips the `0xED` prefix byte before calling ed25519_sign_open; non-canonical sig returns `false`
- `PublicKey` in the stdlib is `[u8; 33]` -- use `&PublicKey` rather than `&[u8]` to enforce the size constraint at the call site


### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (added tests for existing code, or tests for the new feature in this PR)
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [ ] Release

<!--
## Test Plan
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
