### PR TITLE
feat: Migrate types to FieldDecoder, empty_buffer()

### DIFF
--- a/xrpl-common-stdlib/src/fields/decoder.rs
+++ b/xrpl-common-stdlib/src/fields/decoder.rs
@@ -1,56 +1,108 @@
-//! Field decoding traits for XRPL transaction and ledger object fields.
+//! Context-independent decode logic for typed field values.
 //!
-//! This module defines a lightweight, host-independent decoding contract for types that
-//! are constructed directly from a raw byte buffer.
-//!
-//! # Examples
-//!
-//! ```
-//! use xrpl_common_stdlib::fields::decoder::{FieldDecoder, FromCurrentTx};
-//! use xrpl_common_stdlib::host::Error;
-//!
-//! /// A toy field: a single boolean flag byte (0 or 1).
-//! struct Flag(bool);
-//!
-//! impl FieldDecoder for Flag {
-//!     type Buffer = [u8; 1];
-//!
-//!     fn decode(bytes: &[u8]) -> Result<Self, Error> {
-//!         match bytes {
-//!             [0] => Ok(Flag(false)),
-//!             [1] => Ok(Flag(true)),
-//!             _ => Err(Error::InvalidDecoding),
-//!         }
-//!     }
-//! }
-//!
-//! // Declares that `Flag` can be decoded from the currently executing transaction.
-//! // `FromLedger` is implemented the same way for fields readable from ledger objects.
-//! impl FromCurrentTx for Flag {}
-//!
-//! let flag = Flag::decode(&[1]).unwrap();
-//! assert!(flag.0);
-//!
-//! assert!(Flag::decode(&[2]).is_err());
-//! ```
+//! Reading a field always looks the same: call a host function into a buffer, then turn the
+//! bytes it wrote into a typed value. [`FieldDecoder`] captures only that second step, so a type
+//! implements it once regardless of how many contexts (current transaction, ledger object, ...)
+//! can produce those bytes. The marker traits below record which contexts are valid for a given
+//! type at compile time; the context-specific `get_field` functions (see
+//! [`crate::fields::current_tx`], [`crate::fields::ledger_obj`]) require the matching marker.
 
-use crate::host::Error;
+use crate::types::decode_error::DecodeError;
 
-/// Decodes a fixed-format XRPL field from its raw byte representation.
+/// Decodes a typed value from the raw bytes a host function wrote.
 pub trait FieldDecoder: Sized {
-    /// A stack buffer sized to hold this field's raw bytes, used by generic host-field
-    /// getters to read into before calling [`decode`](FieldDecoder::decode).
-    type Buffer: AsMut<[u8]> + Default;
+    /// The buffer a `get_field` caller allocates before invoking the host function. Each type
+    /// picks its own size (an associated type, not a `const`, so this stays on stable Rust).
+    // TODO: once `generic_const_exprs` stabilises (tracking issue rust-lang/rust#76560), replace
+    // this with `const SIZE: usize` and change the bound to `[u8; Self::SIZE]`, removing the
+    // need for `empty_buffer()` entirely.
+    type Buffer: AsMut<[u8]> + AsRef<[u8]>;
 
-    /// Decodes `Self` from `bytes`, returning an error if the bytes are malformed.
-    fn decode(bytes: &[u8]) -> Result<Self, Error>;
+    /// Returns a zero-initialized buffer of this type's `Buffer` size.
+    fn empty_buffer() -> Self::Buffer;
+
+    /// Decodes `Self` from exactly the bytes the host wrote (not the full, possibly
+    /// zero-padded, `Buffer`).
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError>;
 }
 
-/// Marker trait for fields that can be decoded from the currently executing transaction.
+/// Marker: this type can be read from the current transaction via [`crate::fields::current_tx`].
 pub trait FromCurrentTx: FieldDecoder {}
 
-/// Marker trait for fields that can be decoded from a ledger object.
+/// Marker: this type can be read from a ledger object via [`crate::fields::ledger_obj`].
 pub trait FromLedger: FieldDecoder {}
+
+impl FieldDecoder for u8 {
+    type Buffer = [u8; 1];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; 1]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let array: Self::Buffer = bytes.try_into().map_err(|_| DecodeError)?;
+        Ok(u8::from_le_bytes(array))
+    }
+}
+
+impl FromCurrentTx for u8 {}
+impl FromLedger for u8 {}
+
+impl FieldDecoder for u16 {
+    type Buffer = [u8; 2];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; 2]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let array: Self::Buffer = bytes.try_into().map_err(|_| DecodeError)?;
+        Ok(u16::from_le_bytes(array))
+    }
+}
+
+impl FromCurrentTx for u16 {}
+impl FromLedger for u16 {}
+
+impl FieldDecoder for u32 {
+    type Buffer = [u8; 4];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; 4]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let array: Self::Buffer = bytes.try_into().map_err(|_| DecodeError)?;
+        Ok(u32::from_le_bytes(array))
+    }
+}
+
+impl FromCurrentTx for u32 {}
+impl FromLedger for u32 {}
+
+impl FieldDecoder for u64 {
+    type Buffer = [u8; 8];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; 8]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let array: Self::Buffer = bytes.try_into().map_err(|_| DecodeError)?;
+        Ok(u64::from_le_bytes(array))
+    }
+}
+
+impl FromCurrentTx for u64 {}
+impl FromLedger for u64 {}
 
 #[cfg(test)]
 mod tests {
@@ -62,12 +114,12 @@ mod tests {
     impl FieldDecoder for TxOnly {
         type Buffer = [u8; 1];
 
-        fn decode(bytes: &[u8]) -> Result<Self, Error> {
-            bytes
-                .first()
-                .copied()
-                .map(TxOnly)
-                .ok_or(Error::FieldNotFound)
+        fn empty_buffer() -> Self::Buffer {
+            [0u8; 1]
+        }
+
+        fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+            bytes.first().copied().map(TxOnly).ok_or(DecodeError)
         }
     }
     impl FromCurrentTx for TxOnly {}
@@ -78,12 +130,12 @@ mod tests {
     impl FieldDecoder for ObjOnly {
         type Buffer = [u8; 1];
 
-        fn decode(bytes: &[u8]) -> Result<Self, Error> {
-            bytes
-                .first()
-                .copied()
-                .map(ObjOnly)
-                .ok_or(Error::FieldNotFound)
+        fn empty_buffer() -> Self::Buffer {
+            [0u8; 1]
+        }
+
+        fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+            bytes.first().copied().map(ObjOnly).ok_or(DecodeError)
         }
     }
     impl FromLedger for ObjOnly {}
@@ -94,19 +146,21 @@ mod tests {
     impl FieldDecoder for TxAndObj {
         type Buffer = [u8; 1];
 
-        fn decode(bytes: &[u8]) -> Result<Self, Error> {
-            bytes
-                .first()
-                .copied()
-                .map(TxAndObj)
-                .ok_or(Error::FieldNotFound)
+        fn empty_buffer() -> Self::Buffer {
+            [0u8; 1]
+        }
+
+        fn decode(bytes: &[u8]) -> Result<Self, DecodeError> {
+            bytes.first().copied().map(TxAndObj).ok_or(DecodeError)
         }
     }
     impl FromCurrentTx for TxAndObj {}
     impl FromLedger for TxAndObj {}
 
     // These take no arguments and are never called; if a type didn't actually implement
-    // the trait, the crate would fail to compile.
+    // the trait, the crate would fail to compile. The negative direction (a type that
+    // implements only one marker being rejected by the other) is covered by the
+    // `tests/decoder_compile_fail.rs` trybuild cases.
     fn assert_from_current_tx<T: FromCurrentTx>() {}
     fn assert_from_ledger<T: FromLedger>() {}
 
@@ -128,20 +182,17 @@ mod tests {
 
     #[test]
     fn decode_returns_value_on_success() {
-        let decoded = TxOnly::decode(&[42]).unwrap();
-        assert_eq!(decoded, TxOnly(42));
+        assert_eq!(TxOnly::decode(&[42]), Ok(TxOnly(42)));
     }
 
     #[test]
     fn decode_returns_error_on_empty_input() {
-        let result = TxOnly::decode(&[]);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().code(), Error::FieldNotFound.code());
+        assert_eq!(TxOnly::decode(&[]), Err(DecodeError));
     }
 
     #[test]
-    fn buffer_type_has_expected_length() {
-        let mut buffer = <TxOnly as FieldDecoder>::Buffer::default();
+    fn empty_buffer_has_expected_length() {
+        let mut buffer = <TxOnly as FieldDecoder>::empty_buffer();
         assert_eq!(buffer.as_mut().len(), 1);
     }
 }

--- a/xrpl-common-stdlib/src/types/account_id.rs
+++ b/xrpl-common-stdlib/src/types/account_id.rs
@@ -4,12 +4,14 @@
 //! See also: <https://xrpl.org/docs/references/protocol/common-fields#accountid-fields>
 
 use crate::current_tx::CurrentTxFieldGetter;
+use crate::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger};
 use crate::host::field_helpers::{
     get_fixed_size_field_with_expected_bytes, get_fixed_size_field_with_expected_bytes_optional,
 };
 use crate::host::{Result, get_current_ledger_obj_field, get_ledger_obj_field, get_tx_field};
 use crate::objects::LedgerObjectFieldGetter;
 use crate::sfield::SField;
+use crate::types::decode_error::DecodeError;
 
 pub const ACCOUNT_ID_SIZE: usize = 20;
 
@@ -123,3 +125,23 @@ impl CurrentTxFieldGetter for AccountID {
         .map(|buffer| buffer.map(|b| b.into()))
     }
 }
+
+/// `FieldDecoder` for XRPL account identifiers: decodes a 20-byte buffer into an `AccountID`,
+/// failing if the host wrote a different number of bytes.
+impl FieldDecoder for AccountID {
+    type Buffer = [u8; ACCOUNT_ID_SIZE];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; ACCOUNT_ID_SIZE]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> core::result::Result<Self, DecodeError> {
+        let array: Self::Buffer = bytes.try_into().map_err(|_| DecodeError)?;
+        Ok(array.into())
+    }
+}
+
+impl FromCurrentTx for AccountID {}
+impl FromLedger for AccountID {}

--- a/xrpl-common-stdlib/src/types/amount.rs
+++ b/xrpl-common-stdlib/src/types/amount.rs
@@ -386,10 +386,8 @@ impl FieldDecoder for Amount {
 
     #[inline]
     fn decode(bytes: &[u8]) -> core::result::Result<Self, DecodeError> {
-        let mut padded = [0u8; AMOUNT_SIZE];
-        let n = bytes.len().min(AMOUNT_SIZE);
-        padded[..n].copy_from_slice(&bytes[..n]);
-        Amount::from_bytes(&padded).ok().ok_or(DecodeError)
+        let amount_bytes: [u8; AMOUNT_SIZE] = bytes.try_into().map_err(|_| DecodeError)?;
+        Amount::from_bytes(&amount_bytes).ok().ok_or(DecodeError)
     }
 }
 

--- a/xrpl-common-stdlib/src/types/amount.rs
+++ b/xrpl-common-stdlib/src/types/amount.rs
@@ -1,4 +1,5 @@
 use crate::current_tx::CurrentTxFieldGetter;
+use crate::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger};
 use crate::host;
 use crate::host::Error::InvalidParams;
 use crate::host::Result::{Err, Ok};
@@ -8,6 +9,7 @@ use crate::objects::LedgerObjectFieldGetter;
 use crate::sfield::SField;
 use crate::types::account_id::AccountID;
 use crate::types::currency::Currency;
+use crate::types::decode_error::DecodeError;
 use crate::types::mpt_id::MptId;
 use crate::types::opaque_float::OpaqueFloat;
 
@@ -370,6 +372,29 @@ impl CurrentTxFieldGetter for Amount {
         .map(|opt| opt.map(|(buffer, _len)| Amount::from(buffer)))
     }
 }
+
+/// `FieldDecoder` for XRPL amount values: zero-pads whatever bytes the host wrote (an XRP amount
+/// is only 8 bytes, MPT 33, IOU the full 48) up to `AMOUNT_SIZE`, then parses via
+/// `Amount::from_bytes`, mapping any parse failure to `DecodeError`.
+impl FieldDecoder for Amount {
+    type Buffer = [u8; AMOUNT_SIZE];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; AMOUNT_SIZE]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> core::result::Result<Self, DecodeError> {
+        let mut padded = [0u8; AMOUNT_SIZE];
+        let n = bytes.len().min(AMOUNT_SIZE);
+        padded[..n].copy_from_slice(&bytes[..n]);
+        Amount::from_bytes(&padded).ok().ok_or(DecodeError)
+    }
+}
+
+impl FromCurrentTx for Amount {}
+impl FromLedger for Amount {}
 
 #[cfg(test)]
 mod tests {

--- a/xrpl-common-stdlib/src/types/blob.rs
+++ b/xrpl-common-stdlib/src/types/blob.rs
@@ -1,8 +1,10 @@
 use crate::current_tx::CurrentTxFieldGetter;
+use crate::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger};
 use crate::host::field_helpers::{get_variable_size_field, get_variable_size_field_optional};
 use crate::host::{Result, get_current_ledger_obj_field, get_ledger_obj_field, get_tx_field};
 use crate::objects::LedgerObjectFieldGetter;
 use crate::sfield::SField;
+use crate::types::decode_error::DecodeError;
 
 /// Default blob size for general use (memos, etc.)
 pub const DEFAULT_BLOB_SIZE: usize = 1024;
@@ -249,6 +251,26 @@ impl<const N: usize> CurrentTxFieldGetter for Blob<N> {
         .map(|opt| opt.map(|(data, len)| Blob { data, len }))
     }
 }
+
+/// `FieldDecoder` for any `Blob<N>`: copies whatever bytes the host wrote (at most `N`) into a
+/// `Blob<N>`, recording the actual length. Unlike fixed-size types, this never fails — blobs are
+/// variable-length by design.
+impl<const N: usize> FieldDecoder for Blob<N> {
+    type Buffer = [u8; N];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; N]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> core::result::Result<Self, DecodeError> {
+        Ok(Blob::from_slice(bytes))
+    }
+}
+
+impl<const N: usize> FromCurrentTx for Blob<N> {}
+impl<const N: usize> FromLedger for Blob<N> {}
 
 #[cfg(test)]
 mod tests {

--- a/xrpl-common-stdlib/src/types/decode_error.rs
+++ b/xrpl-common-stdlib/src/types/decode_error.rs
@@ -1,0 +1,9 @@
+//! Pure decode-failure signal for [`crate::fields::decoder::FieldDecoder`].
+
+/// Signals that a byte slice could not be decoded into a typed value.
+///
+/// Implemented so `types/` has no dependency on `host/`. The `fields/`
+/// getters (`current_tx::get_field`, `ledger_obj::get_field`, ...) are the place this
+/// gets mapped to `host::Error::InvalidDecoding`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodeError;

--- a/xrpl-common-stdlib/src/types/mod.rs
+++ b/xrpl-common-stdlib/src/types/mod.rs
@@ -5,6 +5,7 @@ pub mod blob;
 pub mod constants;
 pub mod contract_data;
 pub mod currency;
+pub mod decode_error;
 pub mod issue;
 pub mod mpt_id;
 pub mod nft;

--- a/xrpl-common-stdlib/src/types/public_key.rs
+++ b/xrpl-common-stdlib/src/types/public_key.rs
@@ -1,10 +1,3 @@
-use crate::current_tx::CurrentTxFieldGetter;
-use crate::host::field_helpers::{
-    get_fixed_size_field_with_expected_bytes, get_fixed_size_field_with_expected_bytes_optional,
-};
-use crate::host::{Result, get_tx_field};
-use crate::sfield::SField;
-
 pub const PUBLIC_KEY_BUFFER_SIZE: usize = 33;
 
 /// A 33-byte public key for secp256k1 and ed25519 DSA types.
@@ -43,39 +36,6 @@ impl From<&[u8]> for PublicKey {
         key_bytes[..bytes.len().min(PUBLIC_KEY_BUFFER_SIZE)]
             .copy_from_slice(&bytes[..bytes.len().min(PUBLIC_KEY_BUFFER_SIZE)]);
         PublicKey(key_bytes)
-    }
-}
-
-/// Implementation of `CurrentTxFieldGetter` for XRPL public keys.
-///
-/// This implementation handles 33-byte compressed public key fields in XRPL transactions.
-/// Public keys are used for cryptographic signature verification and are commonly found
-/// in the SigningPubKey field and various other cryptographic contexts.
-///
-/// # Buffer Management
-///
-/// Uses a 33-byte buffer and validates that exactly 33 bytes are returned
-/// from the host function. The buffer is converted to a PublicKey using
-/// the `From<[u8; 33]>` implementation.
-impl CurrentTxFieldGetter for PublicKey {
-    #[inline]
-    fn get_from_current_tx<const CODE: i32>(field: SField<Self, CODE>) -> Result<Self> {
-        get_fixed_size_field_with_expected_bytes::<33, _>(
-            i32::from(field),
-            |fc, buf, size| unsafe { get_tx_field(fc, buf, size) },
-        )
-        .map(|buffer| buffer.into())
-    }
-
-    #[inline]
-    fn get_from_current_tx_optional<const CODE: i32>(
-        field: SField<Self, CODE>,
-    ) -> Result<Option<Self>> {
-        get_fixed_size_field_with_expected_bytes_optional::<33, _>(
-            i32::from(field),
-            |fc, buf, size| unsafe { get_tx_field(fc, buf, size) },
-        )
-        .map(|buffer| buffer.map(|b| b.into()))
     }
 }
 

--- a/xrpl-common-stdlib/src/types/transaction_type.rs
+++ b/xrpl-common-stdlib/src/types/transaction_type.rs
@@ -1,9 +1,11 @@
 use crate::current_tx::CurrentTxFieldGetter;
+use crate::fields::decoder::{FieldDecoder, FromCurrentTx};
 use crate::host::field_helpers::{
     get_fixed_size_field_with_expected_bytes, get_fixed_size_field_with_expected_bytes_optional,
 };
 use crate::host::{Result, get_tx_field};
 use crate::sfield::SField;
+use crate::types::decode_error::DecodeError;
 
 /// The type of any given XRPL transaction.
 ///
@@ -186,6 +188,27 @@ impl CurrentTxFieldGetter for TransactionType {
         .map(|buffer| buffer.map(|b| i16::from_le_bytes(b).into()))
     }
 }
+
+/// `FieldDecoder` for XRPL transaction types: decodes a 2-byte buffer via the existing
+/// (infallible) `i16` mapping, failing only if the host wrote a different number of bytes.
+impl FieldDecoder for TransactionType {
+    type Buffer = [u8; 2];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; 2]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> core::result::Result<Self, DecodeError> {
+        let array: Self::Buffer = bytes.try_into().map_err(|_| DecodeError)?;
+        Ok(array.into())
+    }
+}
+
+// Tx-only: the transaction type is a transaction field. Ledger objects carry `LedgerEntryType`
+// as `SField<u16, _>`, not `SField<TransactionType, _>`, so there is no `FromLedger` impl here.
+impl FromCurrentTx for TransactionType {}
 
 #[cfg(test)]
 mod tests {

--- a/xrpl-common-stdlib/src/types/uint.rs
+++ b/xrpl-common-stdlib/src/types/uint.rs
@@ -1,12 +1,14 @@
 //! Generic unsigned integer types with configurable bit sizes
 
 use crate::current_tx::CurrentTxFieldGetter;
+use crate::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger};
 use crate::host::field_helpers::{
     get_fixed_size_field_with_expected_bytes, get_fixed_size_field_with_expected_bytes_optional,
 };
 use crate::host::{Result, get_current_ledger_obj_field, get_ledger_obj_field, get_tx_field};
 use crate::objects::LedgerObjectFieldGetter;
 use crate::sfield::SField;
+use crate::types::decode_error::DecodeError;
 
 /// A generic unsigned integer type with configurable byte size.
 ///
@@ -208,6 +210,30 @@ impl CurrentTxFieldGetter for Hash256 {
         .map(|buffer| buffer.map(|b| b.into()))
     }
 }
+
+/// `FieldDecoder` for any fixed-width unsigned integer (`Hash128`/`Hash160`/`Hash192`/`Hash256`,
+/// and any other `UInt<N>` instantiation): decodes an `N`-byte buffer into `UInt<N>`, failing if
+/// the host wrote a different number of bytes.
+impl<const N: usize> FieldDecoder for UInt<N> {
+    type Buffer = [u8; N];
+
+    #[inline]
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; N]
+    }
+
+    #[inline]
+    fn decode(bytes: &[u8]) -> core::result::Result<Self, DecodeError> {
+        let array: Self::Buffer = bytes.try_into().map_err(|_| DecodeError)?;
+        Ok(array.into())
+    }
+}
+
+// Only `Hash256` is marked readable; the narrower hash widths (`Hash128`/`Hash160`/`Hash192`)
+// already have the generic `FieldDecoder` impl above and gain `FromCurrentTx`/`FromLedger`
+// if and when a field typed to them needs to be read.
+impl FromCurrentTx for Hash256 {}
+impl FromLedger for Hash256 {}
 
 #[cfg(test)]
 mod tests {

--- a/xrpl-common-stdlib/tests/decoder/fail_obj_only_missing_from_current_tx.rs
+++ b/xrpl-common-stdlib/tests/decoder/fail_obj_only_missing_from_current_tx.rs
@@ -2,14 +2,18 @@
 //! requires `FromCurrentTx` must fail to compile.
 
 use xrpl_common_stdlib::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger};
-use xrpl_common_stdlib::host::Error;
+use xrpl_common_stdlib::types::decode_error::DecodeError;
 
 struct ObjOnly;
 
 impl FieldDecoder for ObjOnly {
     type Buffer = [u8; 1];
 
-    fn decode(_bytes: &[u8]) -> Result<Self, Error> {
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; 1]
+    }
+
+    fn decode(_bytes: &[u8]) -> Result<Self, DecodeError> {
         Ok(ObjOnly)
     }
 }

--- a/xrpl-common-stdlib/tests/decoder/fail_obj_only_missing_from_current_tx.stderr
+++ b/xrpl-common-stdlib/tests/decoder/fail_obj_only_missing_from_current_tx.stderr
@@ -1,11 +1,21 @@
 error[E0277]: the trait bound `ObjOnly: FromCurrentTx` is not satisfied
-  --> tests/decoder/fail_obj_only_missing_from_current_tx.rs:22:32
+  --> tests/decoder/fail_obj_only_missing_from_current_tx.rs:26:32
    |
-22 |     requires_from_current_tx::<ObjOnly>();
+26 |     requires_from_current_tx::<ObjOnly>();
    |                                ^^^^^^^ the trait `FromCurrentTx` is not implemented for `ObjOnly`
    |
+   = help: the following other types implement trait `FromCurrentTx`:
+             AccountID
+             Amount
+             Blob<N>
+             TransactionType
+             UInt<xrpl_common_stdlib::::types::uint::UInt256::{constant#0}>
+             u16
+             u32
+             u64
+             u8
 note: required by a bound in `requires_from_current_tx`
-  --> tests/decoder/fail_obj_only_missing_from_current_tx.rs:19:32
+  --> tests/decoder/fail_obj_only_missing_from_current_tx.rs:23:32
    |
-19 | fn requires_from_current_tx<T: FromCurrentTx>() {}
+23 | fn requires_from_current_tx<T: FromCurrentTx>() {}
    |                                ^^^^^^^^^^^^^ required by this bound in `requires_from_current_tx`

--- a/xrpl-common-stdlib/tests/decoder/fail_tx_only_missing_from_ledger.rs
+++ b/xrpl-common-stdlib/tests/decoder/fail_tx_only_missing_from_ledger.rs
@@ -2,14 +2,18 @@
 //! requires `FromLedger` must fail to compile.
 
 use xrpl_common_stdlib::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger};
-use xrpl_common_stdlib::host::Error;
+use xrpl_common_stdlib::types::decode_error::DecodeError;
 
 struct TxOnly;
 
 impl FieldDecoder for TxOnly {
     type Buffer = [u8; 1];
 
-    fn decode(_bytes: &[u8]) -> Result<Self, Error> {
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; 1]
+    }
+
+    fn decode(_bytes: &[u8]) -> Result<Self, DecodeError> {
         Ok(TxOnly)
     }
 }

--- a/xrpl-common-stdlib/tests/decoder/fail_tx_only_missing_from_ledger.stderr
+++ b/xrpl-common-stdlib/tests/decoder/fail_tx_only_missing_from_ledger.stderr
@@ -1,11 +1,20 @@
 error[E0277]: the trait bound `TxOnly: FromLedger` is not satisfied
-  --> tests/decoder/fail_tx_only_missing_from_ledger.rs:22:28
+  --> tests/decoder/fail_tx_only_missing_from_ledger.rs:26:28
    |
-22 |     requires_from_ledger::<TxOnly>();
+26 |     requires_from_ledger::<TxOnly>();
    |                            ^^^^^^ the trait `FromLedger` is not implemented for `TxOnly`
    |
+   = help: the following other types implement trait `FromLedger`:
+             AccountID
+             Amount
+             Blob<N>
+             UInt<xrpl_common_stdlib::::types::uint::UInt256::{constant#0}>
+             u16
+             u32
+             u64
+             u8
 note: required by a bound in `requires_from_ledger`
-  --> tests/decoder/fail_tx_only_missing_from_ledger.rs:19:28
+  --> tests/decoder/fail_tx_only_missing_from_ledger.rs:23:28
    |
-19 | fn requires_from_ledger<T: FromLedger>() {}
+23 | fn requires_from_ledger<T: FromLedger>() {}
    |                            ^^^^^^^^^^ required by this bound in `requires_from_ledger`


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

The PR title must follow the Conventional Commits format:
  <type>: <Description>

The description must start with a capital letter.
Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, release, example.
See CONTRIBUTING.md for details.
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

Split of #214 to contain only the diffs for empty_buffer() addition to FieldDecoder and accompanying migrations on types. The following PR will contain the next stage of the split.

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (added tests for existing code, or tests for the new feature in this PR)
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [ ] Release

<!--
## Test Plan
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
