### PR TITLE
fix: Reduce Blob byte copies

### DIFF
--- a/xrpl-common-stdlib/src/fields/current_tx.rs
+++ b/xrpl-common-stdlib/src/fields/current_tx.rs
@@ -26,8 +26,10 @@
 
 use crate::fields::decoder::{FromCurrentTx, decode_result};
 use crate::host::error_codes::FIELD_NOT_FOUND;
-use crate::host::{Result, get_tx_field};
+use crate::host::{Error, Result, get_tx_field};
 use crate::sfield::SField;
+use crate::types::blob::Blob;
+use core::mem::MaybeUninit;
 
 /// Retrieves a field from the current transaction using an SField constant.
 ///
@@ -99,9 +101,69 @@ pub fn get_field_optional<T: FromCurrentTx, const CODE: i32>(
     decode_result::<T>(buf, n).map(Some)
 }
 
+// --- `Blob<N>`-specific accessors ------------------------------------------------------------
+//
+// See the matching comment in `fields::ledger_obj` for the full rationale — this is the same
+// zero-copy accessor, mirrored here for reading `Blob<N>` fields off the current transaction
+// instead of a cached ledger object. In short: the generic `get_field`/`get_field_optional`
+// above allocate their own scratch buffer and then reconstruct `T` from it, which for large
+// `Blob<N>` values (e.g. `WasmBlob`, N = 4096) compiles to a real, measured ~4092-byte `memcpy`
+// under this crate's size-optimized (`opt-level = "s"`) release profile. These functions instead
+// have the host write straight into the returned `Blob<N>`'s own `data` field, so no such
+// reconstruction — and no such copy — ever happens. Deliberately not folded into the generic
+// path, which stays untouched for every other (small, copy-is-negligible) field type.
+
+/// Retrieves a `Blob<N>` field from the current transaction, writing the host's bytes directly
+/// into the returned `Blob<N>`'s own storage. See the module comment block above for why
+/// `Blob<N>` gets a dedicated accessor instead of using [`get_field`].
+#[inline]
+pub fn get_blob_field<const N: usize, const CODE: i32>(
+    _: SField<Blob<N>, CODE>,
+) -> Result<Blob<N>> {
+    let mut blob = MaybeUninit::<Blob<N>>::uninit();
+    // SAFETY: `data_ptr` points at the `data` field inside `blob`'s own (uninitialized) storage;
+    // `blob` outlives this pointer and no other reference to it exists yet.
+    let data_ptr = unsafe { core::ptr::addr_of_mut!((*blob.as_mut_ptr()).data) } as *mut u8;
+    // Zero the destination *before* the host call: a result code of 0 is a legitimate "empty
+    // field" success (not an error), and `Blob::data` is `pub`, so callers may read past `len`
+    // directly. Zeroing in place (rather than in a separate scratch buffer) costs the same one
+    // `memset` the old code paid anyway, just at the final address instead of a temporary one.
+    unsafe { core::ptr::write_bytes(data_ptr, 0u8, N) };
+    let n = unsafe { get_tx_field(CODE, data_ptr, N) };
+    if n < 0 {
+        return Result::Err(Error::from_code(n));
+    }
+    if n as usize > N {
+        // A conformant host never reports writing more bytes than the buffer holds.
+        return Result::Err(Error::PointerOutOfBounds);
+    }
+    // SAFETY: `data` was fully zeroed above and then (partially) overwritten by the host, so
+    // every byte is initialized; `len` is set right before `assume_init`, completing the value.
+    unsafe {
+        core::ptr::addr_of_mut!((*blob.as_mut_ptr()).len).write(n as usize);
+        Result::Ok(blob.assume_init())
+    }
+}
+
+/// Optional variant of [`get_blob_field`]: returns `Ok(None)` if the field is not present,
+/// otherwise behaves identically (including the direct-write zero-copy behavior). Implemented
+/// in terms of [`get_blob_field`] itself rather than duplicating its body — `Error::FieldNotFound`
+/// round-trips exactly through `Error::from_code`/`.code()` (both are just `FIELD_NOT_FOUND`),
+/// so translating that one error case into `None` is all this needs to do.
+#[inline]
+pub fn get_blob_field_optional<const N: usize, const CODE: i32>(
+    field: SField<Blob<N>, CODE>,
+) -> Result<Option<Blob<N>>> {
+    match get_blob_field(field) {
+        Result::Ok(blob) => Result::Ok(Some(blob)),
+        Result::Err(Error::FieldNotFound) => Result::Ok(None),
+        Result::Err(e) => Result::Err(e),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{get_field, get_field_optional};
+    use super::{get_blob_field, get_blob_field_optional, get_field, get_field_optional};
     use crate::fields::decoder::FieldDecoder;
     use crate::host::error_codes::{FIELD_NOT_FOUND, INTERNAL_ERROR};
     use crate::host::host_bindings_trait::MockHostBindings;
@@ -221,5 +283,105 @@ mod tests {
             result.err().unwrap().code(),
             crate::host::Error::PointerOutOfBounds.code()
         );
+    }
+
+    #[test]
+    fn test_get_blob_field_writes_bytes_directly_into_blob_data() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_tx_field()
+            .with(eq::<i32>(sfield::PublicKey.into()), always(), eq(33))
+            .times(1)
+            .returning(|_, buf, size| {
+                // Simulate the host writing 33 bytes of non-zero data.
+                let slice = unsafe { core::slice::from_raw_parts_mut(buf, size) };
+                slice.fill(0xAB);
+                size as i32
+            });
+        let _guard = setup_mock(mock);
+
+        let blob = get_blob_field(sfield::PublicKey).unwrap();
+        assert_eq!(blob.len(), 33);
+        assert!(blob.as_slice().iter().all(|&b| b == 0xAB));
+    }
+
+    #[test]
+    fn test_get_blob_field_zeroes_tail_when_host_writes_fewer_bytes() {
+        // A short write (e.g. an empty/undersized field) must leave the tail zeroed, not
+        // uninitialized -- `Blob::data` is `pub`, so callers may read past `len` directly.
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_tx_field()
+            .with(eq::<i32>(sfield::PublicKey.into()), always(), eq(33))
+            .times(1)
+            .returning(|_, buf, _size| {
+                let slice = unsafe { core::slice::from_raw_parts_mut(buf, 10) };
+                slice.fill(0xFF);
+                10
+            });
+        let _guard = setup_mock(mock);
+
+        let blob = get_blob_field(sfield::PublicKey).unwrap();
+        assert_eq!(blob.len(), 10);
+        assert_eq!(blob.data[9], 0xFF);
+        assert_eq!(blob.data[10], 0);
+        assert_eq!(blob.data[32], 0);
+    }
+
+    #[test]
+    fn test_get_blob_field_returns_err_on_internal_error() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_tx_field()
+            .with(eq::<i32>(sfield::PublicKey.into()), always(), eq(33))
+            .times(1)
+            .returning(|_, _, _| INTERNAL_ERROR);
+        let _guard = setup_mock(mock);
+
+        let result = get_blob_field(sfield::PublicKey);
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn test_get_blob_field_returns_err_when_host_reports_oversized_write() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_tx_field()
+            .with(eq::<i32>(sfield::PublicKey.into()), always(), eq(33))
+            .times(1)
+            .returning(|_, _, _| 34); // claims 34 bytes into a 33-byte buffer
+        let _guard = setup_mock(mock);
+
+        let result = get_blob_field(sfield::PublicKey);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().code(),
+            crate::host::Error::PointerOutOfBounds.code()
+        );
+    }
+
+    #[test]
+    fn test_get_blob_field_optional_returns_none_on_field_not_found() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_tx_field()
+            .with(eq::<i32>(sfield::PublicKey.into()), always(), eq(33))
+            .times(1)
+            .returning(|_, _, _| FIELD_NOT_FOUND);
+        let _guard = setup_mock(mock);
+
+        let result = get_blob_field_optional(sfield::PublicKey);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_get_blob_field_optional_returns_some_when_present() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_tx_field()
+            .with(eq::<i32>(sfield::PublicKey.into()), always(), eq(33))
+            .times(1)
+            .returning(|_, _, _| 33);
+        let _guard = setup_mock(mock);
+
+        let result = get_blob_field_optional(sfield::PublicKey);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_some());
     }
 }

--- a/xrpl-common-stdlib/src/fields/ledger_obj.rs
+++ b/xrpl-common-stdlib/src/fields/ledger_obj.rs
@@ -7,8 +7,10 @@
 
 use crate::fields::decoder::{FromLedger, decode_result};
 use crate::host::error_codes::FIELD_NOT_FOUND;
-use crate::host::{Result, get_ledger_obj_field};
+use crate::host::{Error, Result, get_ledger_obj_field};
 use crate::sfield::SField;
+use crate::types::blob::Blob;
+use core::mem::MaybeUninit;
 
 /// Retrieves a field from the ledger object cached in `slot` using an SField constant.
 ///
@@ -51,9 +53,86 @@ pub fn get_field_optional<T: FromLedger, const CODE: i32>(
     decode_result::<T>(buf, n).map(Some)
 }
 
+// --- `Blob<N>`-specific accessors ------------------------------------------------------------
+//
+// Why these exist (rather than just calling the generic `get_field`/`get_field_optional` above,
+// which `Blob<N>` is also eligible for via `FromLedger`):
+//
+// The generic path allocates `T::empty_buffer()` as its own local, has the host write into it,
+// and then hands that buffer to `T::decode` to build the returned `T`. For small fixed-size
+// types (`u32`, `AccountID`, ...) that "move" from the local buffer into the returned value is
+// reliably optimized away. For `Blob<N>` it is not: `Blob<N>` is `{ data: [u8; N], len: usize }`,
+// a different memory shape than the bare `[u8; N]` buffer `get_field` allocates, so building the
+// `Blob` from that buffer is a genuine field-by-field reconstruction, not just a reinterpret. We
+// verified with `wasm2wat` against this crate's actual release profile (`opt-level = "s"`,
+// `lto = true`, `codegen-units = 1`) that for `WasmBlob` (N = 4096) this reconstruction compiles
+// to a real ~4092-byte `memcpy` per read — `-Os` does not fuse it away the way `-O2`/`-O3` might.
+//
+// The fix is to give the host nothing to reconstruct from: allocate the `Blob<N>` itself first,
+// and point the host straight at its `data` field, so the bytes land in their final resting
+// place on the very first (and only) write. There is then no second, distinctly-addressed buffer
+// for the optimizer to have to notice is redundant — the copy is structurally absent rather than
+// hoped-away.
+//
+// This is deliberately NOT folded into the generic `get_field`/`get_field_optional`/`FieldDecoder`
+// machinery above, which is shared by every other field type (`u8..u64`, `AccountID`, `Amount`,
+// `UInt<N>`, `TransactionType`) where the buffer is small enough that the copy is already
+// negligible/elided. Scoping the fix to `Blob<N>` alone avoids adding raw-pointer plumbing to
+// code paths that don't need it.
+
+/// Retrieves a `Blob<N>` field from the ledger object cached in `slot`, writing the host's bytes
+/// directly into the returned `Blob<N>`'s own storage. See the comment above this function for
+/// why `Blob<N>` gets a dedicated accessor instead of using [`get_field`].
+#[inline]
+pub fn get_blob_field<const N: usize, const CODE: i32>(
+    slot: i32,
+    _: SField<Blob<N>, CODE>,
+) -> Result<Blob<N>> {
+    let mut blob = MaybeUninit::<Blob<N>>::uninit();
+    // SAFETY: `data_ptr` points at the `data` field inside `blob`'s own (uninitialized) storage;
+    // `blob` outlives this pointer and no other reference to it exists yet.
+    let data_ptr = unsafe { core::ptr::addr_of_mut!((*blob.as_mut_ptr()).data) } as *mut u8;
+    // Zero the destination *before* the host call: a result code of 0 is a legitimate "empty
+    // field" success (not an error), and `Blob::data` is `pub`, so callers may read past `len`
+    // directly. Zeroing in place (rather than in a separate scratch buffer) costs the same one
+    // `memset` the old code paid anyway, just at the final address instead of a temporary one.
+    unsafe { core::ptr::write_bytes(data_ptr, 0u8, N) };
+    let n = unsafe { get_ledger_obj_field(slot, CODE, data_ptr, N) };
+    if n < 0 {
+        return Result::Err(Error::from_code(n));
+    }
+    if n as usize > N {
+        // A conformant host never reports writing more bytes than the buffer holds.
+        return Result::Err(Error::PointerOutOfBounds);
+    }
+    // SAFETY: `data` was fully zeroed above and then (partially) overwritten by the host, so
+    // every byte is initialized; `len` is set right before `assume_init`, completing the value.
+    unsafe {
+        core::ptr::addr_of_mut!((*blob.as_mut_ptr()).len).write(n as usize);
+        Result::Ok(blob.assume_init())
+    }
+}
+
+/// Optional variant of [`get_blob_field`]: returns `Ok(None)` if the field is not present,
+/// otherwise behaves identically (including the direct-write zero-copy behavior). Implemented
+/// in terms of [`get_blob_field`] itself rather than duplicating its body — `Error::FieldNotFound`
+/// round-trips exactly through `Error::from_code`/`.code()` (both are just `FIELD_NOT_FOUND`),
+/// so translating that one error case into `None` is all this needs to do.
+#[inline]
+pub fn get_blob_field_optional<const N: usize, const CODE: i32>(
+    slot: i32,
+    field: SField<Blob<N>, CODE>,
+) -> Result<Option<Blob<N>>> {
+    match get_blob_field(slot, field) {
+        Result::Ok(blob) => Result::Ok(Some(blob)),
+        Result::Err(Error::FieldNotFound) => Result::Ok(None),
+        Result::Err(e) => Result::Err(e),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{get_field, get_field_optional};
+    use super::{get_blob_field, get_blob_field_optional, get_field, get_field_optional};
     use crate::host::error_codes::{FIELD_NOT_FOUND, INTERNAL_ERROR};
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::host::setup_mock;
@@ -175,5 +254,127 @@ mod tests {
             result.err().unwrap().code(),
             crate::host::Error::PointerOutOfBounds.code()
         );
+    }
+
+    #[test]
+    fn test_get_blob_field_writes_bytes_directly_into_blob_data() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_field()
+            .with(
+                eq(SLOT),
+                eq::<i32>(sfield::Condition.into()),
+                always(),
+                eq(128),
+            )
+            .times(1)
+            .returning(|_, _, buf, size| {
+                // Simulate the host writing 128 bytes of non-zero data.
+                let slice = unsafe { core::slice::from_raw_parts_mut(buf, size) };
+                slice.fill(0xAB);
+                size as i32
+            });
+        let _guard = setup_mock(mock);
+
+        let blob = get_blob_field(SLOT, sfield::Condition).unwrap();
+        assert_eq!(blob.len(), 128);
+        assert!(blob.as_slice().iter().all(|&b| b == 0xAB));
+    }
+
+    #[test]
+    fn test_get_blob_field_zeroes_tail_when_host_writes_fewer_bytes() {
+        // A short write (e.g. an empty/undersized field) must leave the tail zeroed, not
+        // uninitialized -- `Blob::data` is `pub`, so callers may read past `len` directly.
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_field()
+            .with(
+                eq(SLOT),
+                eq::<i32>(sfield::Condition.into()),
+                always(),
+                eq(128),
+            )
+            .times(1)
+            .returning(|_, _, buf, _size| {
+                let slice = unsafe { core::slice::from_raw_parts_mut(buf, 10) };
+                slice.fill(0xFF);
+                10
+            });
+        let _guard = setup_mock(mock);
+
+        let blob = get_blob_field(SLOT, sfield::Condition).unwrap();
+        assert_eq!(blob.len(), 10);
+        assert_eq!(blob.data[9], 0xFF);
+        assert_eq!(blob.data[10], 0);
+        assert_eq!(blob.data[127], 0);
+    }
+
+    #[test]
+    fn test_get_blob_field_returns_err_on_internal_error() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_field()
+            .with(
+                eq(SLOT),
+                eq::<i32>(sfield::Condition.into()),
+                always(),
+                eq(128),
+            )
+            .times(1)
+            .returning(|_, _, _, _| INTERNAL_ERROR);
+        let _guard = setup_mock(mock);
+
+        let result = get_blob_field(SLOT, sfield::Condition);
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn test_get_blob_field_returns_err_when_host_reports_oversized_write() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_field()
+            .with(
+                eq(SLOT),
+                eq::<i32>(sfield::Condition.into()),
+                always(),
+                eq(128),
+            )
+            .times(1)
+            .returning(|_, _, _, _| 129); // claims 129 bytes into a 128-byte buffer
+        let _guard = setup_mock(mock);
+
+        let result = get_blob_field(SLOT, sfield::Condition);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().code(),
+            crate::host::Error::PointerOutOfBounds.code()
+        );
+    }
+
+    #[test]
+    fn test_get_blob_field_optional_returns_none_on_field_not_found() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_field()
+            .with(
+                eq(SLOT),
+                eq::<i32>(sfield::Condition.into()),
+                always(),
+                eq(128),
+            )
+            .times(1)
+            .returning(|_, _, _, _| FIELD_NOT_FOUND);
+        let _guard = setup_mock(mock);
+
+        let result = get_blob_field_optional(SLOT, sfield::Condition);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_get_blob_field_optional_returns_some_when_present() {
+        let mut mock = MockHostBindings::new();
+        expect_ledger_obj_field(&mut mock, SLOT, sfield::Condition.into(), 128, 1);
+        let _guard = setup_mock(mock);
+
+        let result = get_blob_field_optional(SLOT, sfield::Condition);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_some());
     }
 }


### PR DESCRIPTION
Adds Blob<N>-specific zero-copy accessors — get_blob_field/get_blob_field_optional in both fields::current_tx and fields::ledger_obj — that write host bytes directly into the returned Blob<N>'s own memory, eliminating an avoidable memcpy on every large-blob field read.

The generic get_field/get_field_optional (used by every FieldDecoder type: u8..u64, AccountID, Amount, UInt<N>, TransactionType, and Blob<N>) allocate their own local buffer, have the host write into it, then reconstruct the returned T from that buffer. For small fixed-size types that reconstruction is reliably optimized away. For Blob<N> it is not — Blob<N> is { data: [u8; N], len: usize }, a different memory shape than the bare [u8; N] the generic path allocates, so building the Blob is a genuine field-by-field reconstruction rather than a reinterpret.

Confirmed empirically compiling the actual generic-path retrieval of a WasmBlob (N = 4096) against this crate's real release profile (opt-level = "s", lto = true, codegen-units = 1) and disassembling with wasm2wat shows a genuine ~4092-byte memcpy per read — -Os doesn't fuse the redundant copy away the way -O2/-O3 might.