### PR TITLE
feat: Ledger locator path + shared path builder

### DIFF
--- a/e2e-tests/trace_escrow_ledger_object/src/lib.rs
+++ b/e2e-tests/trace_escrow_ledger_object/src/lib.rs
@@ -23,6 +23,8 @@ const EXPECTED_CONDITION: [u8; 39] = [
 use xrpl_common_stdlib::host::trace::{DataRepr, trace, trace_amount, trace_data, trace_num};
 use xrpl_common_stdlib::host::{Result::Err, Result::Ok};
 use xrpl_common_stdlib::objects::traits::CurrentLedgerObjectCommonFields;
+use xrpl_common_stdlib::sfield;
+use xrpl_common_stdlib::types::account_id::AccountID;
 use xrpl_escrow_stdlib::ledger_objects::current_escrow::{CurrentEscrow, get_current_escrow};
 use xrpl_escrow_stdlib::ledger_objects::traits::CurrentEscrowFields;
 
@@ -182,6 +184,87 @@ pub extern "C" fn finish() -> i32 {
         }
 
         let _ = trace("}");
+        let _ = trace("");
+    }
+
+    // ########################################
+    // Read the same fields through the nested-field path builder
+    // ########################################
+    //
+    // `current_escrow.path()` reaches the slot-less `get_current_ledger_obj_nested_field`. A
+    // single-segment path targets a top-level field, so each read below must agree with the flat
+    // getter above — that equality is what proves the locator encoding and the host dispatch are
+    // both correct against a real ledger object, not just against mocks.
+    {
+        let _ = trace("### Current Escrow Ledger Object Fields via path()");
+
+        // Path Read: Account
+        let path_account = current_escrow
+            .path()
+            .field(sfield::Account)
+            .get::<AccountID>()
+            .unwrap();
+        test_utils::assert_eq!(path_account.0, current_escrow.get_account().unwrap().0);
+        let _ = trace_data("  Account (via path):", &path_account.0, DataRepr::AsHex);
+
+        // Path Read: OwnerNode
+        let path_owner_node = current_escrow
+            .path()
+            .field(sfield::OwnerNode)
+            .get::<u64>()
+            .unwrap();
+        test_utils::assert_eq!(path_owner_node, current_escrow.get_owner_node().unwrap());
+        let _ = trace_num("  OwnerNode (via path):", path_owner_node as i64);
+
+        // Path Read: PreviousTxnLgrSeq
+        let path_prev_lgr_seq = current_escrow
+            .path()
+            .field(sfield::PreviousTxnLgrSeq)
+            .get::<u32>()
+            .unwrap();
+        test_utils::assert_eq!(
+            path_prev_lgr_seq,
+            current_escrow.get_previous_txn_lgr_seq().unwrap()
+        );
+        let _ = trace_num("  PreviousTxnLgrSeq (via path):", path_prev_lgr_seq as i64);
+
+        // Path Read: DestinationTag, an optional field that runTest.js does set. Both routes must
+        // agree it is present, and agree on the value.
+        let path_dest_tag = current_escrow
+            .path()
+            .field(sfield::DestinationTag)
+            .get_optional::<u32>()
+            .unwrap();
+        let flat_dest_tag = current_escrow.get_destination_tag().unwrap();
+        test_utils::assert!(path_dest_tag.is_some());
+        test_utils::assert!(flat_dest_tag.is_some());
+        test_utils::assert_eq!(path_dest_tag.unwrap(), flat_dest_tag.unwrap());
+        let _ = trace_num(
+            "  DestinationTag (via path):",
+            path_dest_tag.unwrap() as i64,
+        );
+
+        // A path whose segments overflow the 64-byte locator must be rejected locally, without
+        // ever reaching the host.
+        let mut overflowed = current_escrow.path();
+        for i in 0..17 {
+            overflowed = overflowed.index(i);
+        }
+        test_utils::assert!(overflowed.get::<u32>().is_err());
+
+        // `array_len()` against the current object. An Escrow has no array field, so this asks the
+        // host about a non-array and must surface an error rather than a bogus count.
+        let non_array_len = current_escrow.path().field(sfield::Account).array_len();
+        match non_array_len {
+            Ok(len) => {
+                let _ = trace_num("  array_len on non-array returned:", len as i64);
+            }
+            Err(error) => {
+                let _ = trace_num("  array_len on non-array errored:", error.code() as i64);
+            }
+        }
+        test_utils::assert!(non_array_len.is_err());
+
         let _ = trace("");
     }
 

--- a/examples/smart-escrows/oracle/src/lib.rs
+++ b/examples/smart-escrows/oracle/src/lib.rs
@@ -3,11 +3,11 @@
 #[cfg(not(target_arch = "wasm32"))]
 extern crate std;
 
-use xrpl_common_stdlib::fields::locator::Locator;
-use xrpl_common_stdlib::host::error_codes::match_result_code;
-use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
-use xrpl_common_stdlib::host::{Result, Result::Err, Result::Ok};
+use xrpl_common_stdlib::host::trace::{trace, trace_num};
+use xrpl_common_stdlib::host::{Error, Result, Result::Err, Result::Ok};
 use xrpl_common_stdlib::keylets::oracle_keylet;
+use xrpl_common_stdlib::objects::LedgerObject;
+use xrpl_common_stdlib::objects::traits::LedgerObjectCommonFields;
 use xrpl_common_stdlib::r_address;
 use xrpl_common_stdlib::types::account_id::AccountID;
 use xrpl_common_stdlib::{host, sfield};
@@ -18,35 +18,45 @@ const ORACLE_OWNER: AccountID = r_address!("rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh")
 const ORACLE_DOCUMENT_ID: u32 = 1;
 
 pub fn get_price_from_oracle(slot: i32) -> Result<u64> {
-    let mut locator = Locator::new();
-    locator.pack(sfield::PriceDataSeries);
-    locator.pack(0);
-    locator.pack(sfield::AssetPrice);
+    // The Oracle entry has no typed wrapper, so reach its nested fields through the untyped slot
+    // handle. Check the series is non-empty before indexing into it, rather than relying on the
+    // read of [0] to fail.
+    let oracle = LedgerObject::new(slot);
 
-    let mut data: [u8; 8] = [0; 8];
-    let result_code = unsafe {
-        host::get_ledger_obj_nested_field(
-            slot,
-            locator.as_ptr(),
-            locator.num_packed_bytes(),
-            data.as_mut_ptr(),
-            data.len(),
-        )
+    let series_len = match oracle.path().field(sfield::PriceDataSeries).array_len() {
+        Ok(len) => len,
+        Err(error) => {
+            let _ = trace_num("Error getting PriceDataSeries length", error.code() as i64);
+            return Err(error);
+        }
     };
-    let _ = trace_data("get_price_from_oracle: data=", &data, DataRepr::AsHex);
+    let _ = trace_num(
+        "get_price_from_oracle: price_data_series_len=",
+        series_len as i64,
+    );
+    if series_len == 0 {
+        let _ = trace("get_price_from_oracle: oracle has no price data");
+        return Err(Error::FieldNotFound);
+    }
 
-    let asset_price = match match_result_code(result_code, || data) {
-        Ok(asset_bytes) => {
-            let price = u64::from_le_bytes(asset_bytes);
+    // PriceDataSeries[0].AssetPrice
+    let asset_price = oracle
+        .path()
+        .field(sfield::PriceDataSeries)
+        .index(0)
+        .field(sfield::AssetPrice)
+        .get::<u64>();
+
+    match asset_price {
+        Ok(price) => {
             let _ = trace_num("get_price_from_oracle: asset_price=", price as i64);
-            price
+            Ok(price)
         }
         Err(error) => {
             let _ = trace_num("Error getting asset_price", error.code() as i64);
-            return Err(error); // Must return to short circuit.
+            Err(error) // Must return to short circuit.
         }
-    };
-    Ok(asset_price)
+    }
 }
 
 #[smart_escrow]

--- a/xrpl-common-stdlib/src/fields/locator.rs
+++ b/xrpl-common-stdlib/src/fields/locator.rs
@@ -3,10 +3,13 @@
 //!
 //! Two APIs share the same buffer layout:
 //!
-//! - [`TxPathBuilder`] is the recommended fluent builder. It is rooted at the context —
-//!   [`ctx.tx().path()`](crate::current_tx::traits::TransactionCommonFields::path) — so
-//!   no bare buffer escapes and the terminal [`get`](TxPathBuilder::get) always dispatches to the
-//!   current-transaction host function. Field codes come from typed `SField` constants:
+//! - [`TxPathBuilder`] and [`LedgerPathBuilder`] are the recommended fluent builders. Each is
+//!   rooted at its context —
+//!   [`ctx.tx().path()`](crate::current_tx::traits::TransactionCommonFields::path) for the current
+//!   transaction, [`obj.path()`](crate::objects::traits::LedgerObjectCommonFields::path) or
+//!   [`ctx.escrow().path()`](crate::objects::traits::CurrentLedgerObjectCommonFields::path) for a
+//!   ledger object — so no bare buffer escapes and the terminal `get` always dispatches to the
+//!   host function matching that context. Field codes come from typed `SField` constants:
 //!   ```no_run
 //!   use xrpl_common_stdlib::current_tx::traits::TransactionCommonFields;
 //!   use xrpl_common_stdlib::sfield;
@@ -32,8 +35,11 @@
 //!   # let _ = (l.len() >= 3);
 //!   ```
 
-use crate::fields::decoder::{FromCurrentTx, decode_host_result};
-use crate::host::{self, Result, get_tx_nested_field};
+use crate::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger, decode_host_result};
+use crate::host::{
+    self, Result, get_current_ledger_obj_nested_field, get_ledger_obj_nested_field,
+    get_tx_nested_field,
+};
 use crate::sfield::SField;
 
 /// The size of the buffer, in bytes, to use for any new locator
@@ -127,7 +133,97 @@ impl Locator {
     }
 }
 
-/// Fluent builder for reading a nested field from the current transaction.
+/// The retrieval context a [`PathBuf`] reads from: selects which nested-field host function the
+/// terminal `get` calls, and for a slot-cached object carries the slot.
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum NestedSource {
+    /// The current transaction (`get_tx_nested_field`).
+    Tx,
+    /// The ledger object the contract is attached to (`get_current_ledger_obj_nested_field`).
+    CurrentLedgerObj,
+    /// A ledger object cached in the given slot (`get_ledger_obj_nested_field`).
+    LedgerObj(i32),
+}
+
+impl NestedSource {
+    /// Issue this context's nested-field host call for the packed `locator` bytes.
+    fn call(&self, loc_ptr: *const u8, loc_len: usize, out_ptr: *mut u8, out_len: usize) -> i32 {
+        match self {
+            NestedSource::Tx => unsafe { get_tx_nested_field(loc_ptr, loc_len, out_ptr, out_len) },
+            NestedSource::CurrentLedgerObj => unsafe {
+                get_current_ledger_obj_nested_field(loc_ptr, loc_len, out_ptr, out_len)
+            },
+            NestedSource::LedgerObj(slot) => unsafe {
+                get_ledger_obj_nested_field(*slot, loc_ptr, loc_len, out_ptr, out_len)
+            },
+        }
+    }
+}
+
+/// Shared path-building core behind the public builders: the packed [`Locator`] buffer, the sticky
+/// overflow flag, and the [`NestedSource`] to read from. The public wrappers add the context-marker
+/// bound (`FromCurrentTx` vs `FromLedger`) at their signatures; `get` / `get_optional` here are
+/// bounded on [`FieldDecoder`] because that marker is enforced one level up.
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct PathBuf {
+    locator: Locator,
+    /// Set once a `field`/`index` segment did not fit in the buffer. Sticky: further calls stay
+    /// overflowed so `get` reports the malformed path instead of reading a truncated one.
+    overflowed: bool,
+    source: NestedSource,
+}
+
+impl PathBuf {
+    fn new(source: NestedSource) -> Self {
+        Self {
+            locator: Locator::new(),
+            overflowed: false,
+            source,
+        }
+    }
+
+    /// Append one 4-byte segment, recording buffer overflow so `get` can reject a truncated path.
+    fn push(mut self, value: i32) -> Self {
+        if !self.locator.pack(value) {
+            self.overflowed = true;
+        }
+        self
+    }
+
+    fn get<T: FieldDecoder>(&self) -> Result<T> {
+        if self.overflowed {
+            return Result::Err(host::Error::LocatorMalformed);
+        }
+        let (buf, n) = self.read::<T>();
+        decode_host_result::<T>(buf, n)
+    }
+
+    fn get_optional<T: FieldDecoder>(&self) -> Result<Option<T>> {
+        match self.get::<T>() {
+            Result::Ok(value) => Result::Ok(Some(value)),
+            Result::Err(host::Error::FieldNotFound) => Result::Ok(None),
+            Result::Err(e) => Result::Err(e),
+        }
+    }
+
+    /// Run the built path through the source's host call into a fresh `T` buffer, returning that
+    /// buffer and the raw byte count the host reported (negative on error).
+    fn read<T: FieldDecoder>(&self) -> (T::Buffer, i32) {
+        let mut buf = T::empty_buffer();
+        let n = {
+            let slice = buf.as_mut();
+            self.source.call(
+                self.locator.as_ptr(),
+                self.locator.num_packed_bytes(),
+                slice.as_mut_ptr(),
+                slice.len(),
+            )
+        };
+        (buf, n)
+    }
+}
+
+/// Fluent builder for reading a nested field from the **current transaction**.
 ///
 /// Obtained from the context via
 /// [`ctx.tx().path()`](crate::current_tx::traits::TransactionCommonFields::path); rooting
@@ -140,21 +236,13 @@ impl Locator {
 /// truncated: the overflow is remembered and surfaced as [`host::Error::LocatorMalformed`] from
 /// [`get`](Self::get), rather than sending the host a shorter path than the author wrote.
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct TxPathBuilder {
-    locator: Locator,
-    /// Set once a `field`/`index` segment did not fit in the buffer. Sticky: further calls stay
-    /// overflowed so `get` reports the malformed path instead of reading a truncated one.
-    overflowed: bool,
-}
+pub struct TxPathBuilder(PathBuf);
 
 impl TxPathBuilder {
     /// Root a new builder at the current transaction. Callers reach this through
     /// [`TransactionCommonFields::path`](crate::current_tx::traits::TransactionCommonFields::path).
     pub(crate) fn for_current_tx() -> Self {
-        Self {
-            locator: Locator::new(),
-            overflowed: false,
-        }
+        Self(PathBuf::new(NestedSource::Tx))
     }
 
     /// Append a field code to the path.
@@ -163,22 +251,13 @@ impl TxPathBuilder {
     /// compile-time constant; only the code is encoded — the field's declared type `T` is
     /// irrelevant to the path and is chosen instead at [`get`](Self::get).
     pub fn field<T, const CODE: i32>(self, _field: SField<T, CODE>) -> Self {
-        self.push(CODE)
+        Self(self.0.push(CODE))
     }
 
     /// Append an array slot index to the path (e.g. the `0` in `Memos[0]`).
     pub fn index(self, index: u32) -> Self {
         // A u32 and its i32 bit-pattern pack to identical bytes, which is what the host reads back.
-        self.push(index as i32)
-    }
-
-    /// Append one 4-byte segment, recording buffer overflow so [`get`](Self::get) can reject a
-    /// truncated path.
-    fn push(mut self, value: i32) -> Self {
-        if !self.locator.pack(value) {
-            self.overflowed = true;
-        }
-        self
+        Self(self.0.push(index as i32))
     }
 
     /// Execute the `get_tx_nested_field` host call for the built path and decode the result as `T`.
@@ -189,11 +268,7 @@ impl TxPathBuilder {
     /// Returns [`host::Error::LocatorMalformed`] without calling the host if the path overflowed
     /// the buffer while being built.
     pub fn get<T: FromCurrentTx>(&self) -> Result<T> {
-        if self.overflowed {
-            return Result::Err(host::Error::LocatorMalformed);
-        }
-        let (buf, n) = self.read::<T>();
-        decode_host_result::<T>(buf, n)
+        self.0.get::<T>()
     }
 
     /// Like [`get`](Self::get) but treats an absent field as `Ok(None)` rather than an error —
@@ -202,29 +277,57 @@ impl TxPathBuilder {
     ///
     /// Returns [`host::Error::LocatorMalformed`] without calling the host if the path overflowed.
     pub fn get_optional<T: FromCurrentTx>(&self) -> Result<Option<T>> {
-        match self.get::<T>() {
-            Result::Ok(value) => Result::Ok(Some(value)),
-            Result::Err(host::Error::FieldNotFound) => Result::Ok(None),
-            Result::Err(e) => Result::Err(e),
-        }
+        self.0.get_optional::<T>()
+    }
+}
+
+/// Fluent builder for reading a nested field from a **ledger object** — either the object the
+/// contract is attached to, or one cached into a slot.
+///
+/// Obtained from the context via
+/// [`obj.path()`](crate::objects::traits::LedgerObjectCommonFields::path) for a slot-cached object
+/// or [`ctx.escrow().path()`](crate::objects::traits::CurrentLedgerObjectCommonFields::path) for
+/// the current one. Terminal reads are bounded on [`FromLedger`]; behavior otherwise matches
+/// [`TxPathBuilder`], including the overflow → [`host::Error::LocatorMalformed`] guard.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct LedgerPathBuilder(PathBuf);
+
+impl LedgerPathBuilder {
+    /// Root a new builder at the current ledger object (no slot). Callers reach this through
+    /// [`CurrentLedgerObjectCommonFields::path`](crate::objects::traits::CurrentLedgerObjectCommonFields::path).
+    pub(crate) fn for_current_ledger_obj() -> Self {
+        Self(PathBuf::new(NestedSource::CurrentLedgerObj))
     }
 
-    /// Run the built path through `get_tx_nested_field` into a fresh `T` buffer, returning that
-    /// buffer and the raw byte count the host reported (negative on error).
-    fn read<T: FromCurrentTx>(&self) -> (T::Buffer, i32) {
-        let mut buf = T::empty_buffer();
-        let n = {
-            let slice = buf.as_mut();
-            unsafe {
-                get_tx_nested_field(
-                    self.locator.as_ptr(),
-                    self.locator.num_packed_bytes(),
-                    slice.as_mut_ptr(),
-                    slice.len(),
-                )
-            }
-        };
-        (buf, n)
+    /// Root a new builder at the ledger object cached in `slot`. Callers reach this through
+    /// [`LedgerObjectCommonFields::path`](crate::objects::traits::LedgerObjectCommonFields::path).
+    pub(crate) fn for_ledger_obj(slot: i32) -> Self {
+        Self(PathBuf::new(NestedSource::LedgerObj(slot)))
+    }
+
+    /// Append a field code to the path. See [`TxPathBuilder::field`].
+    pub fn field<T, const CODE: i32>(self, _field: SField<T, CODE>) -> Self {
+        Self(self.0.push(CODE))
+    }
+
+    /// Append an array slot index to the path (e.g. the `0` in `SignerEntries[0]`).
+    pub fn index(self, index: u32) -> Self {
+        Self(self.0.push(index as i32))
+    }
+
+    /// Execute the ledger-object nested-field host call for the built path and decode as `T`.
+    ///
+    /// `T` must be readable from a ledger object, hence the [`FromLedger`] bound. Returns
+    /// [`host::Error::LocatorMalformed`] without calling the host if the path overflowed.
+    pub fn get<T: FromLedger>(&self) -> Result<T> {
+        self.0.get::<T>()
+    }
+
+    /// Like [`get`](Self::get) but treats an absent field as `Ok(None)` rather than an error —
+    /// the nested-path counterpart to
+    /// [`get_field_optional`](crate::fields::ledger_obj::get_field_optional).
+    pub fn get_optional<T: FromLedger>(&self) -> Result<Option<T>> {
+        self.0.get_optional::<T>()
     }
 }
 
@@ -364,14 +467,14 @@ mod tests {
 
     /// The bytes a `TxPathBuilder` has packed so far, for asserting on the encoded path.
     fn packed(builder: &TxPathBuilder) -> &[u8] {
-        &builder.locator.buffer[..builder.locator.cur_buffer_index]
+        &builder.0.locator.buffer[..builder.0.locator.cur_buffer_index]
     }
 
     #[test]
     fn test_tx_field_encodes_single_field_code() {
         let builder = TxPathBuilder::for_current_tx().field(sfield::Sequence);
 
-        assert!(!builder.overflowed);
+        assert!(!builder.0.overflowed);
         assert_eq!(packed(&builder), &i32::from(sfield::Sequence).to_le_bytes());
     }
 
@@ -381,7 +484,7 @@ mod tests {
             .field(sfield::Memos)
             .field(sfield::MemoData);
 
-        assert!(!builder.overflowed);
+        assert!(!builder.0.overflowed);
         let bytes = packed(&builder);
         assert_eq!(bytes.len(), 8);
         assert_eq!(&bytes[0..4], &i32::from(sfield::Memos).to_le_bytes());
@@ -396,7 +499,7 @@ mod tests {
             .index(2)
             .field(sfield::MemoType);
 
-        assert!(!builder.overflowed);
+        assert!(!builder.0.overflowed);
         let bytes = packed(&builder);
         assert_eq!(bytes.len(), 12);
         assert_eq!(&bytes[0..4], &i32::from(sfield::Memos).to_le_bytes());
@@ -411,13 +514,13 @@ mod tests {
         for i in 0..16 {
             builder = builder.index(i);
         }
-        assert!(!builder.overflowed);
-        assert_eq!(builder.locator.num_packed_bytes(), 64);
+        assert!(!builder.0.overflowed);
+        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
 
         let builder = builder.field(sfield::Sequence);
-        assert!(builder.overflowed);
+        assert!(builder.0.overflowed);
         // The buffer is not grown or partially overwritten past its capacity.
-        assert_eq!(builder.locator.num_packed_bytes(), 64);
+        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
     }
 
     #[test]
@@ -427,12 +530,12 @@ mod tests {
         for _ in 0..16 {
             builder = builder.field(sfield::Sequence);
         }
-        assert!(!builder.overflowed);
-        assert_eq!(builder.locator.num_packed_bytes(), 64);
+        assert!(!builder.0.overflowed);
+        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
 
         let builder = builder.index(99);
-        assert!(builder.overflowed);
-        assert_eq!(builder.locator.num_packed_bytes(), 64);
+        assert!(builder.0.overflowed);
+        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
     }
 
     #[test]
@@ -465,7 +568,7 @@ mod tests {
         for i in 0..17 {
             builder = builder.index(i);
         }
-        assert!(builder.overflowed);
+        assert!(builder.0.overflowed);
 
         let result = builder.get::<u32>();
         assert!(result.is_err());
@@ -523,6 +626,171 @@ mod tests {
 
         let result = TxPathBuilder::for_current_tx()
             .field(sfield::Sequence)
+            .get_optional::<u32>();
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    // ---- Fluent path builder (`obj.path()` / `ctx.escrow().path()`) ----
+
+    /// The bytes a `LedgerPathBuilder` has packed so far, for asserting on the encoded path.
+    fn ledger_packed(builder: &LedgerPathBuilder) -> &[u8] {
+        &builder.0.locator.buffer[..builder.0.locator.cur_buffer_index]
+    }
+
+    #[test]
+    fn test_ledger_field_encodes_single_field_code() {
+        let builder = LedgerPathBuilder::for_current_ledger_obj().field(sfield::Flags);
+
+        assert!(!builder.0.overflowed);
+        assert_eq!(
+            ledger_packed(&builder),
+            &i32::from(sfield::Flags).to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn test_ledger_index_encodes_array_slot() {
+        // SignerEntries[2].Account
+        let builder = LedgerPathBuilder::for_ledger_obj(1)
+            .field(sfield::SignerEntries)
+            .index(2)
+            .field(sfield::Account);
+
+        assert!(!builder.0.overflowed);
+        let bytes = ledger_packed(&builder);
+        assert_eq!(bytes.len(), 12);
+        assert_eq!(
+            &bytes[0..4],
+            &i32::from(sfield::SignerEntries).to_le_bytes()
+        );
+        assert_eq!(&bytes[4..8], &2u32.to_le_bytes());
+        assert_eq!(&bytes[8..12], &i32::from(sfield::Account).to_le_bytes());
+    }
+
+    #[test]
+    fn test_ledger_overflow_sets_flag_and_stops_at_64_bytes() {
+        // Fill all 16 slots (64 bytes) with array indices, then one more field can't fit.
+        let mut builder = LedgerPathBuilder::for_current_ledger_obj();
+        for i in 0..16 {
+            builder = builder.index(i);
+        }
+        assert!(!builder.0.overflowed);
+        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
+
+        let builder = builder.field(sfield::Flags);
+        assert!(builder.0.overflowed);
+        // The buffer is not grown or partially overwritten past its capacity.
+        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
+    }
+
+    #[test]
+    fn test_ledger_current_get_reads_via_current_obj_host_fn() {
+        // A builder rooted at the current object must not reach for the slot-taking host function.
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_current_ledger_obj_nested_field()
+            .with(always(), eq(4usize), always(), eq(4usize))
+            .times(1)
+            .returning(|_, _, _, _| 4);
+        mock.expect_get_ledger_obj_nested_field().times(0);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_current_ledger_obj()
+            .field(sfield::Flags)
+            .get::<u32>();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_ledger_by_slot_get_passes_slot_to_slot_host_fn() {
+        const SLOT: i32 = 7;
+        let mut mock = MockHostBindings::new();
+        // Path is SignerEntries[0] -> two 4-byte segments = 8 bytes; u32 read buffer is 4.
+        mock.expect_get_ledger_obj_nested_field()
+            .with(eq(SLOT), always(), eq(8usize), always(), eq(4usize))
+            .times(1)
+            .returning(|_, _, _, _, _| 4);
+        mock.expect_get_current_ledger_obj_nested_field().times(0);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_ledger_obj(SLOT)
+            .field(sfield::SignerEntries)
+            .index(0)
+            .get::<u32>();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_ledger_get_returns_locator_malformed_when_overflowed_without_calling_host() {
+        // The host must not be queried for a path we know is truncated.
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_nested_field().times(0);
+        let _guard = setup_mock(mock);
+
+        let mut builder = LedgerPathBuilder::for_ledger_obj(1);
+        for i in 0..17 {
+            builder = builder.index(i);
+        }
+        assert!(builder.0.overflowed);
+
+        let result = builder.get::<u32>();
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().code(),
+            host::Error::LocatorMalformed.code()
+        );
+    }
+
+    #[test]
+    fn test_ledger_get_propagates_host_error() {
+        use crate::host::error_codes::INTERNAL_ERROR;
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_current_ledger_obj_nested_field()
+            .with(always(), eq(4usize), always(), eq(4usize))
+            .times(1)
+            .returning(|_, _, _, _| INTERNAL_ERROR);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_current_ledger_obj()
+            .field(sfield::Flags)
+            .get::<u32>();
+
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn test_ledger_get_optional_returns_some_when_present() {
+        const SLOT: i32 = 2;
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_nested_field()
+            .with(eq(SLOT), always(), eq(4usize), always(), eq(4usize))
+            .times(1)
+            .returning(|_, _, _, _, _| 4);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_ledger_obj(SLOT)
+            .field(sfield::Flags)
+            .get_optional::<u32>();
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_some());
+    }
+
+    #[test]
+    fn test_ledger_get_optional_returns_none_on_field_not_found() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_current_ledger_obj_nested_field()
+            .with(always(), eq(4usize), always(), eq(4usize))
+            .times(1)
+            .returning(|_, _, _, _| FIELD_NOT_FOUND);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_current_ledger_obj()
+            .field(sfield::Flags)
             .get_optional::<u32>();
 
         assert!(result.is_ok());

--- a/xrpl-common-stdlib/src/fields/locator.rs
+++ b/xrpl-common-stdlib/src/fields/locator.rs
@@ -35,7 +35,7 @@
 //!   # let _ = (l.len() >= 3);
 //!   ```
 
-use crate::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger, decode_host_result};
+use crate::fields::decoder::{FromCurrentTx, FromLedger, decode_host_result};
 use crate::host::{
     self, Result, get_current_ledger_obj_nested_array_len, get_current_ledger_obj_nested_field,
     get_ledger_obj_nested_array_len, get_ledger_obj_nested_field, get_tx_nested_field,
@@ -281,92 +281,6 @@ impl LedgerSource {
     }
 }
 
-/// Path-building core shared by the two ledger sources: the packed [`Locator`] buffer, the sticky
-/// overflow flag, and the [`LedgerSource`] to read from. Two sources times two terminals
-/// (`get_field` / `array_len`) is what makes this worth factoring out; the public
-/// [`LedgerPathBuilder`] adds the [`FromLedger`] bound at its signatures, so `get` here is bounded
-/// only on [`FieldDecoder`].
-#[derive(Clone, PartialEq, Eq, Debug)]
-struct LedgerPath {
-    locator: Locator,
-    /// Set once a segment could not be encoded — either it did not fit in the buffer, or an
-    /// `index` exceeded [`i32::MAX`]. Sticky: further calls stay malformed so the terminals report
-    /// the bad path instead of reading a truncated or misencoded one.
-    overflowed: bool,
-    source: LedgerSource,
-}
-
-impl LedgerPath {
-    fn new(source: LedgerSource) -> Self {
-        Self {
-            locator: Locator::new(),
-            overflowed: false,
-            source,
-        }
-    }
-
-    /// Append one 4-byte segment, recording overflow so the terminals can reject a truncated path.
-    fn push(mut self, value: i32) -> Self {
-        if !self.locator.pack(value) {
-            self.overflowed = true;
-        }
-        self
-    }
-
-    /// Mark the path unusable without appending anything, for a segment that cannot be encoded.
-    fn mark_malformed(mut self) -> Self {
-        self.overflowed = true;
-        self
-    }
-
-    fn get<T: FieldDecoder>(&self) -> Result<T> {
-        if self.overflowed {
-            return Result::Err(host::Error::LocatorMalformed);
-        }
-        let (buf, n) = self.read::<T>();
-        decode_host_result::<T>(buf, n)
-    }
-
-    fn get_optional<T: FieldDecoder>(&self) -> Result<Option<T>> {
-        match self.get::<T>() {
-            Result::Ok(value) => Result::Ok(Some(value)),
-            Result::Err(host::Error::FieldNotFound) => Result::Ok(None),
-            Result::Err(e) => Result::Err(e),
-        }
-    }
-
-    /// Ask the host how many entries the array at this path holds.
-    fn array_len(&self) -> Result<u32> {
-        if self.overflowed {
-            return Result::Err(host::Error::LocatorMalformed);
-        }
-        let n = self
-            .source
-            .read_array_len(self.locator.as_ptr(), self.locator.num_packed_bytes());
-        if n < 0 {
-            return Result::Err(host::Error::from_code(n));
-        }
-        // A zero-length array is a legitimate answer, not an error.
-        Result::Ok(n as u32)
-    }
-
-    /// Run the built path through the source's host call into a fresh `T` buffer, returning that
-    /// buffer and the raw byte count the host reported (negative on error).
-    fn read<T: FieldDecoder>(&self) -> (T::Buffer, i32) {
-        let mut buf = T::empty_buffer();
-        let n = {
-            let slice = buf.as_mut();
-            self.source.read_field(
-                self.locator.as_ptr(),
-                self.locator.num_packed_bytes(),
-                slice.as_mut_ptr(),
-                slice.len(),
-            )
-        };
-        (buf, n)
-    }
-}
-
 /// Fluent builder for reading a nested field from a ledger object — either the object the contract
 /// is attached to, or one cached into a slot.
 ///
@@ -374,11 +288,13 @@ impl LedgerPath {
 /// [`obj.path()`](crate::objects::traits::LedgerObjectCommonFields::path) for a slot-cached object
 /// or [`ctx.escrow().path()`](crate::objects::traits::CurrentLedgerObjectCommonFields::path) for the
 /// current one. Any object type works, including ones with no bespoke wrapper: reach for
-/// [`LedgerObject::new(slot)`](crate::objects::LedgerObject::new) to build a handle
-/// around a raw slot from `cache_ledger_obj`.
+/// [`LedgerObject::new(slot)`](crate::objects::LedgerObject::new) to build a handle around a raw slot
+/// from `cache_ledger_obj`.
 ///
-/// Terminal reads are bounded on [`FromLedger`]; behavior otherwise matches [`TxPathBuilder`],
-/// including the overflow → [`host::Error::LocatorMalformed`] guard.
+/// Mirrors [`TxPathBuilder`] — same [`Locator`] buffer, same overflow →
+/// [`host::Error::LocatorMalformed`] guard — with two differences: terminal reads are bounded on
+/// [`FromLedger`] instead of [`FromCurrentTx`], and a [`LedgerSource`] picks which of the two
+/// ledger-object host functions to call.
 ///
 /// ```no_run
 /// use xrpl_common_stdlib::host::Result;
@@ -400,24 +316,39 @@ impl LedgerPath {
 /// # }
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct LedgerPathBuilder(LedgerPath);
+pub struct LedgerPathBuilder {
+    locator: Locator,
+    /// Set once a segment could not be encoded — either it did not fit in the buffer, or an
+    /// `index` exceeded [`i32::MAX`]. Sticky: further calls stay malformed so the terminals report
+    /// the bad path instead of reading a truncated or misencoded one.
+    overflowed: bool,
+    source: LedgerSource,
+}
 
 impl LedgerPathBuilder {
     /// Root a new builder at the current ledger object (no slot). Callers reach this through
     /// [`CurrentLedgerObjectCommonFields::path`](crate::objects::traits::CurrentLedgerObjectCommonFields::path).
     pub(crate) fn for_current_ledger_obj() -> Self {
-        Self(LedgerPath::new(LedgerSource::Current))
+        Self::new(LedgerSource::Current)
     }
 
     /// Root a new builder at the ledger object cached in `slot`. Callers reach this through
     /// [`LedgerObjectCommonFields::path`](crate::objects::traits::LedgerObjectCommonFields::path).
     pub(crate) fn for_ledger_obj(slot: i32) -> Self {
-        Self(LedgerPath::new(LedgerSource::Slot(slot)))
+        Self::new(LedgerSource::Slot(slot))
+    }
+
+    fn new(source: LedgerSource) -> Self {
+        Self {
+            locator: Locator::new(),
+            overflowed: false,
+            source,
+        }
     }
 
     /// Append a field code to the path. See [`TxPathBuilder::field`].
     pub fn field<T, const CODE: i32>(self, _field: SField<T, CODE>) -> Self {
-        Self(self.0.push(CODE))
+        self.push(CODE)
     }
 
     /// Append an array slot index to the path (e.g. the `0` in `SignerEntries[0]`).
@@ -425,11 +356,22 @@ impl LedgerPathBuilder {
     /// Locator segments are `i32`, so an index above [`i32::MAX`] would pack as a negative value the
     /// host would read back as a field code. Rather than encode that, the path is marked malformed
     /// and the terminals report [`host::Error::LocatorMalformed`].
-    pub fn index(self, index: u32) -> Self {
+    pub fn index(mut self, index: u32) -> Self {
         match i32::try_from(index) {
-            Ok(index) => Self(self.0.push(index)),
-            Err(_) => Self(self.0.mark_malformed()),
+            Ok(index) => self.push(index),
+            Err(_) => {
+                self.overflowed = true;
+                self
+            }
         }
+    }
+
+    /// Append one 4-byte segment, recording overflow so the terminals can reject a truncated path.
+    fn push(mut self, value: i32) -> Self {
+        if !self.locator.pack(value) {
+            self.overflowed = true;
+        }
+        self
     }
 
     /// Execute the ledger-object nested-field host call for the built path and decode as `T`.
@@ -437,7 +379,11 @@ impl LedgerPathBuilder {
     /// `T` must be readable from a ledger object, hence the [`FromLedger`] bound. Returns
     /// [`host::Error::LocatorMalformed`] without calling the host if the path is malformed.
     pub fn get<T: FromLedger>(&self) -> Result<T> {
-        self.0.get::<T>()
+        if self.overflowed {
+            return Result::Err(host::Error::LocatorMalformed);
+        }
+        let (buf, n) = self.read::<T>();
+        decode_host_result::<T>(buf, n)
     }
 
     /// Like [`get`](Self::get) but treats an absent field as `Ok(None)` rather than an error —
@@ -450,7 +396,11 @@ impl LedgerPathBuilder {
     /// [`ledger_obj::get_blob_field_optional`](crate::fields::ledger_obj::get_blob_field_optional)
     /// exists to handle for flat fields.
     pub fn get_optional<T: FromLedger>(&self) -> Result<Option<T>> {
-        self.0.get_optional::<T>()
+        match self.get::<T>() {
+            Result::Ok(value) => Result::Ok(Some(value)),
+            Result::Err(host::Error::FieldNotFound) => Result::Ok(None),
+            Result::Err(e) => Result::Err(e),
+        }
     }
 
     /// Ask the host how many entries the array at this path holds, so it can be iterated.
@@ -460,7 +410,33 @@ impl LedgerPathBuilder {
     /// present-but-empty array, and [`host::Error::LocatorMalformed`] without calling the host if
     /// the path is malformed.
     pub fn array_len(&self) -> Result<u32> {
-        self.0.array_len()
+        if self.overflowed {
+            return Result::Err(host::Error::LocatorMalformed);
+        }
+        let n = self
+            .source
+            .read_array_len(self.locator.as_ptr(), self.locator.num_packed_bytes());
+        if n < 0 {
+            return Result::Err(host::Error::from_code(n));
+        }
+        // A zero-length array is a legitimate answer, not an error.
+        Result::Ok(n as u32)
+    }
+
+    /// Run the built path through the source's host call into a fresh `T` buffer, returning that
+    /// buffer and the raw byte count the host reported (negative on error).
+    fn read<T: FromLedger>(&self) -> (T::Buffer, i32) {
+        let mut buf = T::empty_buffer();
+        let n = {
+            let slice = buf.as_mut();
+            self.source.read_field(
+                self.locator.as_ptr(),
+                self.locator.num_packed_bytes(),
+                slice.as_mut_ptr(),
+                slice.len(),
+            )
+        };
+        (buf, n)
     }
 }
 
@@ -769,14 +745,14 @@ mod tests {
 
     /// The bytes a `LedgerPathBuilder` has packed so far, for asserting on the encoded path.
     fn ledger_packed(builder: &LedgerPathBuilder) -> &[u8] {
-        &builder.0.locator.buffer[..builder.0.locator.cur_buffer_index]
+        &builder.locator.buffer[..builder.locator.cur_buffer_index]
     }
 
     #[test]
     fn test_ledger_field_encodes_single_field_code() {
         let builder = LedgerPathBuilder::for_current_ledger_obj().field(sfield::Flags);
 
-        assert!(!builder.0.overflowed);
+        assert!(!builder.overflowed);
         assert_eq!(
             ledger_packed(&builder),
             &i32::from(sfield::Flags).to_le_bytes()
@@ -791,7 +767,7 @@ mod tests {
             .index(2)
             .field(sfield::Account);
 
-        assert!(!builder.0.overflowed);
+        assert!(!builder.overflowed);
         let bytes = ledger_packed(&builder);
         assert_eq!(bytes.len(), 12);
         assert_eq!(
@@ -809,13 +785,13 @@ mod tests {
         for i in 0..16 {
             builder = builder.index(i);
         }
-        assert!(!builder.0.overflowed);
-        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
+        assert!(!builder.overflowed);
+        assert_eq!(builder.locator.num_packed_bytes(), 64);
 
         let builder = builder.field(sfield::Flags);
-        assert!(builder.0.overflowed);
+        assert!(builder.overflowed);
         // The buffer is not grown or partially overwritten past its capacity.
-        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
+        assert_eq!(builder.locator.num_packed_bytes(), 64);
     }
 
     #[test]
@@ -867,7 +843,7 @@ mod tests {
         for i in 0..17 {
             builder = builder.index(i);
         }
-        assert!(builder.0.overflowed);
+        assert!(builder.overflowed);
 
         let result = builder.get::<u32>();
         assert!(result.is_err());
@@ -943,9 +919,9 @@ mod tests {
             .field(sfield::SignerEntries)
             .index(u32::MAX);
 
-        assert!(builder.0.overflowed);
+        assert!(builder.overflowed);
         // The out-of-range segment is not encoded at all, so only `SignerEntries` is packed.
-        assert_eq!(builder.0.locator.num_packed_bytes(), 4);
+        assert_eq!(builder.locator.num_packed_bytes(), 4);
         assert_eq!(
             builder.get::<u32>().err().unwrap().code(),
             host::Error::LocatorMalformed.code()

--- a/xrpl-common-stdlib/src/fields/locator.rs
+++ b/xrpl-common-stdlib/src/fields/locator.rs
@@ -37,8 +37,8 @@
 
 use crate::fields::decoder::{FieldDecoder, FromCurrentTx, FromLedger, decode_host_result};
 use crate::host::{
-    self, Result, get_current_ledger_obj_nested_field, get_ledger_obj_nested_field,
-    get_tx_nested_field,
+    self, Result, get_current_ledger_obj_nested_array_len, get_current_ledger_obj_nested_field,
+    get_ledger_obj_nested_array_len, get_ledger_obj_nested_field, get_tx_nested_field,
 };
 use crate::sfield::SField;
 
@@ -133,48 +133,171 @@ impl Locator {
     }
 }
 
-/// The retrieval context a [`PathBuf`] reads from: selects which nested-field host function the
-/// terminal `get` calls, and for a slot-cached object carries the slot.
+/// Fluent builder for reading a nested field from the current transaction.
+///
+/// Obtained from the context via
+/// [`ctx.tx().path()`](crate::current_tx::traits::TransactionCommonFields::path); rooting
+/// it there is what guarantees the terminal [`get`](Self::get) reads through the
+/// current-transaction host function and never crosses into a ledger-object read. Each
+/// [`field`](Self::field) / [`index`](Self::index) call appends one 4-byte segment to the
+/// underlying [`Locator`] buffer.
+///
+/// A path longer than the 64-byte buffer (more than 16 segments) can hold is not silently
+/// truncated: the overflow is remembered and surfaced as [`host::Error::LocatorMalformed`] from
+/// [`get`](Self::get), rather than sending the host a shorter path than the author wrote.
 #[derive(Clone, PartialEq, Eq, Debug)]
-enum NestedSource {
-    /// The current transaction (`get_tx_nested_field`).
-    Tx,
-    /// The ledger object the contract is attached to (`get_current_ledger_obj_nested_field`).
-    CurrentLedgerObj,
-    /// A ledger object cached in the given slot (`get_ledger_obj_nested_field`).
-    LedgerObj(i32),
+pub struct TxPathBuilder {
+    locator: Locator,
+    /// Set once a `field`/`index` segment did not fit in the buffer. Sticky: further calls stay
+    /// overflowed so `get` reports the malformed path instead of reading a truncated one.
+    overflowed: bool,
 }
 
-impl NestedSource {
-    /// Issue this context's nested-field host call for the packed `locator` bytes.
-    fn call(&self, loc_ptr: *const u8, loc_len: usize, out_ptr: *mut u8, out_len: usize) -> i32 {
-        match self {
-            NestedSource::Tx => unsafe { get_tx_nested_field(loc_ptr, loc_len, out_ptr, out_len) },
-            NestedSource::CurrentLedgerObj => unsafe {
+impl TxPathBuilder {
+    /// Root a new builder at the current transaction. Callers reach this through
+    /// [`TransactionCommonFields::path`](crate::current_tx::traits::TransactionCommonFields::path).
+    pub(crate) fn for_current_tx() -> Self {
+        Self {
+            locator: Locator::new(),
+            overflowed: false,
+        }
+    }
+
+    /// Append a field code to the path.
+    ///
+    /// Takes a typed [`SField<T, CODE>`] constant (e.g. `sfield::Memos`) so the field code is a
+    /// compile-time constant; only the code is encoded — the field's declared type `T` is
+    /// irrelevant to the path and is chosen instead at [`get`](Self::get).
+    pub fn field<T, const CODE: i32>(self, _field: SField<T, CODE>) -> Self {
+        self.push(CODE)
+    }
+
+    /// Append an array slot index to the path (e.g. the `0` in `Memos[0]`).
+    pub fn index(self, index: u32) -> Self {
+        // A u32 and its i32 bit-pattern pack to identical bytes, which is what the host reads back.
+        self.push(index as i32)
+    }
+
+    /// Append one 4-byte segment, recording buffer overflow so [`get`](Self::get) can reject a
+    /// truncated path.
+    fn push(mut self, value: i32) -> Self {
+        if !self.locator.pack(value) {
+            self.overflowed = true;
+        }
+        self
+    }
+
+    /// Execute the `get_tx_nested_field` host call for the built path and decode the result as `T`.
+    ///
+    /// `T` picks the terminal type (and therefore the read buffer size and decoder); it must be
+    /// readable from a transaction, hence the [`FromCurrentTx`] bound.
+    ///
+    /// Returns [`host::Error::LocatorMalformed`] without calling the host if the path overflowed
+    /// the buffer while being built.
+    pub fn get<T: FromCurrentTx>(&self) -> Result<T> {
+        if self.overflowed {
+            return Result::Err(host::Error::LocatorMalformed);
+        }
+        let (buf, n) = self.read::<T>();
+        decode_host_result::<T>(buf, n)
+    }
+
+    /// Like [`get`](Self::get) but treats an absent field as `Ok(None)` rather than an error —
+    /// the nested-path counterpart to
+    /// [`get_field_optional`](crate::current_tx::get_field_optional).
+    ///
+    /// Returns [`host::Error::LocatorMalformed`] without calling the host if the path overflowed.
+    pub fn get_optional<T: FromCurrentTx>(&self) -> Result<Option<T>> {
+        match self.get::<T>() {
+            Result::Ok(value) => Result::Ok(Some(value)),
+            Result::Err(host::Error::FieldNotFound) => Result::Ok(None),
+            Result::Err(e) => Result::Err(e),
+        }
+    }
+
+    /// Run the built path through `get_tx_nested_field` into a fresh `T` buffer, returning that
+    /// buffer and the raw byte count the host reported (negative on error).
+    fn read<T: FromCurrentTx>(&self) -> (T::Buffer, i32) {
+        let mut buf = T::empty_buffer();
+        let n = {
+            let slice = buf.as_mut();
+            unsafe {
+                get_tx_nested_field(
+                    self.locator.as_ptr(),
+                    self.locator.num_packed_bytes(),
+                    slice.as_mut_ptr(),
+                    slice.len(),
+                )
+            }
+        };
+        (buf, n)
+    }
+}
+
+/// Which ledger object a [`LedgerPath`] reads from: selects the host function the terminals call,
+/// and for a slot-cached object carries the slot.
+///
+/// Deliberately holds only the two *ledger* sources. There is no transaction variant to select, so
+/// "a [`LedgerPathBuilder`] cannot read a transaction field" holds by construction rather than by
+/// convention — the [`FromLedger`] bound on the public terminals is a second line of defense, not
+/// the only one.
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum LedgerSource {
+    /// The ledger object the contract is attached to (`get_current_ledger_obj_nested_field`).
+    Current,
+    /// A ledger object cached in the given slot (`get_ledger_obj_nested_field`).
+    Slot(i32),
+}
+
+impl LedgerSource {
+    /// Issue this source's nested-field host call for the packed `locator` bytes.
+    fn read_field(
+        &self,
+        loc_ptr: *const u8,
+        loc_len: usize,
+        out_ptr: *mut u8,
+        out_len: usize,
+    ) -> i32 {
+        match *self {
+            LedgerSource::Current => unsafe {
                 get_current_ledger_obj_nested_field(loc_ptr, loc_len, out_ptr, out_len)
             },
-            NestedSource::LedgerObj(slot) => unsafe {
-                get_ledger_obj_nested_field(*slot, loc_ptr, loc_len, out_ptr, out_len)
+            LedgerSource::Slot(slot) => unsafe {
+                get_ledger_obj_nested_field(slot, loc_ptr, loc_len, out_ptr, out_len)
+            },
+        }
+    }
+
+    /// Issue this source's nested-array-length host call for the packed `locator` bytes.
+    fn read_array_len(&self, loc_ptr: *const u8, loc_len: usize) -> i32 {
+        match *self {
+            LedgerSource::Current => unsafe {
+                get_current_ledger_obj_nested_array_len(loc_ptr, loc_len)
+            },
+            LedgerSource::Slot(slot) => unsafe {
+                get_ledger_obj_nested_array_len(slot, loc_ptr, loc_len)
             },
         }
     }
 }
 
-/// Shared path-building core behind the public builders: the packed [`Locator`] buffer, the sticky
-/// overflow flag, and the [`NestedSource`] to read from. The public wrappers add the context-marker
-/// bound (`FromCurrentTx` vs `FromLedger`) at their signatures; `get` / `get_optional` here are
-/// bounded on [`FieldDecoder`] because that marker is enforced one level up.
+/// Path-building core shared by the two ledger sources: the packed [`Locator`] buffer, the sticky
+/// overflow flag, and the [`LedgerSource`] to read from. Two sources times two terminals
+/// (`get_field` / `array_len`) is what makes this worth factoring out; the public
+/// [`LedgerPathBuilder`] adds the [`FromLedger`] bound at its signatures, so `get` here is bounded
+/// only on [`FieldDecoder`].
 #[derive(Clone, PartialEq, Eq, Debug)]
-struct PathBuf {
+struct LedgerPath {
     locator: Locator,
-    /// Set once a `field`/`index` segment did not fit in the buffer. Sticky: further calls stay
-    /// overflowed so `get` reports the malformed path instead of reading a truncated one.
+    /// Set once a segment could not be encoded — either it did not fit in the buffer, or an
+    /// `index` exceeded [`i32::MAX`]. Sticky: further calls stay malformed so the terminals report
+    /// the bad path instead of reading a truncated or misencoded one.
     overflowed: bool,
-    source: NestedSource,
+    source: LedgerSource,
 }
 
-impl PathBuf {
-    fn new(source: NestedSource) -> Self {
+impl LedgerPath {
+    fn new(source: LedgerSource) -> Self {
         Self {
             locator: Locator::new(),
             overflowed: false,
@@ -182,11 +305,17 @@ impl PathBuf {
         }
     }
 
-    /// Append one 4-byte segment, recording buffer overflow so `get` can reject a truncated path.
+    /// Append one 4-byte segment, recording overflow so the terminals can reject a truncated path.
     fn push(mut self, value: i32) -> Self {
         if !self.locator.pack(value) {
             self.overflowed = true;
         }
+        self
+    }
+
+    /// Mark the path unusable without appending anything, for a segment that cannot be encoded.
+    fn mark_malformed(mut self) -> Self {
+        self.overflowed = true;
         self
     }
 
@@ -206,13 +335,28 @@ impl PathBuf {
         }
     }
 
+    /// Ask the host how many entries the array at this path holds.
+    fn array_len(&self) -> Result<u32> {
+        if self.overflowed {
+            return Result::Err(host::Error::LocatorMalformed);
+        }
+        let n = self
+            .source
+            .read_array_len(self.locator.as_ptr(), self.locator.num_packed_bytes());
+        if n < 0 {
+            return Result::Err(host::Error::from_code(n));
+        }
+        // A zero-length array is a legitimate answer, not an error.
+        Result::Ok(n as u32)
+    }
+
     /// Run the built path through the source's host call into a fresh `T` buffer, returning that
     /// buffer and the raw byte count the host reported (negative on error).
     fn read<T: FieldDecoder>(&self) -> (T::Buffer, i32) {
         let mut buf = T::empty_buffer();
         let n = {
             let slice = buf.as_mut();
-            self.source.call(
+            self.source.read_field(
                 self.locator.as_ptr(),
                 self.locator.num_packed_bytes(),
                 slice.as_mut_ptr(),
@@ -223,86 +367,52 @@ impl PathBuf {
     }
 }
 
-/// Fluent builder for reading a nested field from the **current transaction**.
-///
-/// Obtained from the context via
-/// [`ctx.tx().path()`](crate::current_tx::traits::TransactionCommonFields::path); rooting
-/// it there is what guarantees the terminal [`get`](Self::get) reads through the
-/// current-transaction host function and never crosses into a ledger-object read. Each
-/// [`field`](Self::field) / [`index`](Self::index) call appends one 4-byte segment to the
-/// underlying [`Locator`] buffer.
-///
-/// A path longer than the 64-byte buffer (more than 16 segments) can hold is not silently
-/// truncated: the overflow is remembered and surfaced as [`host::Error::LocatorMalformed`] from
-/// [`get`](Self::get), rather than sending the host a shorter path than the author wrote.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub struct TxPathBuilder(PathBuf);
-
-impl TxPathBuilder {
-    /// Root a new builder at the current transaction. Callers reach this through
-    /// [`TransactionCommonFields::path`](crate::current_tx::traits::TransactionCommonFields::path).
-    pub(crate) fn for_current_tx() -> Self {
-        Self(PathBuf::new(NestedSource::Tx))
-    }
-
-    /// Append a field code to the path.
-    ///
-    /// Takes a typed [`SField<T, CODE>`] constant (e.g. `sfield::Memos`) so the field code is a
-    /// compile-time constant; only the code is encoded — the field's declared type `T` is
-    /// irrelevant to the path and is chosen instead at [`get`](Self::get).
-    pub fn field<T, const CODE: i32>(self, _field: SField<T, CODE>) -> Self {
-        Self(self.0.push(CODE))
-    }
-
-    /// Append an array slot index to the path (e.g. the `0` in `Memos[0]`).
-    pub fn index(self, index: u32) -> Self {
-        // A u32 and its i32 bit-pattern pack to identical bytes, which is what the host reads back.
-        Self(self.0.push(index as i32))
-    }
-
-    /// Execute the `get_tx_nested_field` host call for the built path and decode the result as `T`.
-    ///
-    /// `T` picks the terminal type (and therefore the read buffer size and decoder); it must be
-    /// readable from a transaction, hence the [`FromCurrentTx`] bound.
-    ///
-    /// Returns [`host::Error::LocatorMalformed`] without calling the host if the path overflowed
-    /// the buffer while being built.
-    pub fn get<T: FromCurrentTx>(&self) -> Result<T> {
-        self.0.get::<T>()
-    }
-
-    /// Like [`get`](Self::get) but treats an absent field as `Ok(None)` rather than an error —
-    /// the nested-path counterpart to
-    /// [`get_field_optional`](crate::current_tx::get_field_optional).
-    ///
-    /// Returns [`host::Error::LocatorMalformed`] without calling the host if the path overflowed.
-    pub fn get_optional<T: FromCurrentTx>(&self) -> Result<Option<T>> {
-        self.0.get_optional::<T>()
-    }
-}
-
-/// Fluent builder for reading a nested field from a **ledger object** — either the object the
-/// contract is attached to, or one cached into a slot.
+/// Fluent builder for reading a nested field from a ledger object — either the object the contract
+/// is attached to, or one cached into a slot.
 ///
 /// Obtained from the context via
 /// [`obj.path()`](crate::objects::traits::LedgerObjectCommonFields::path) for a slot-cached object
-/// or [`ctx.escrow().path()`](crate::objects::traits::CurrentLedgerObjectCommonFields::path) for
-/// the current one. Terminal reads are bounded on [`FromLedger`]; behavior otherwise matches
-/// [`TxPathBuilder`], including the overflow → [`host::Error::LocatorMalformed`] guard.
+/// or [`ctx.escrow().path()`](crate::objects::traits::CurrentLedgerObjectCommonFields::path) for the
+/// current one. Any object type works, including ones with no bespoke wrapper: reach for
+/// [`LedgerObject::new(slot)`](crate::objects::LedgerObject::new) to build a handle
+/// around a raw slot from `cache_ledger_obj`.
+///
+/// Terminal reads are bounded on [`FromLedger`]; behavior otherwise matches [`TxPathBuilder`],
+/// including the overflow → [`host::Error::LocatorMalformed`] guard.
+///
+/// ```no_run
+/// use xrpl_common_stdlib::host::Result;
+/// use xrpl_common_stdlib::objects::traits::LedgerObjectCommonFields;
+/// use xrpl_common_stdlib::sfield;
+/// # fn demo(obj: &impl LedgerObjectCommonFields) {
+/// // Walk every entry of an array field.
+/// if let Result::Ok(count) = obj.path().field(sfield::PriceDataSeries).array_len() {
+///     for i in 0..count {
+///         let price = obj
+///             .path()
+///             .field(sfield::PriceDataSeries)
+///             .index(i)
+///             .field(sfield::AssetPrice)
+///             .get::<u64>();
+///         # let _ = price;
+///     }
+/// }
+/// # }
+/// ```
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct LedgerPathBuilder(PathBuf);
+pub struct LedgerPathBuilder(LedgerPath);
 
 impl LedgerPathBuilder {
     /// Root a new builder at the current ledger object (no slot). Callers reach this through
     /// [`CurrentLedgerObjectCommonFields::path`](crate::objects::traits::CurrentLedgerObjectCommonFields::path).
     pub(crate) fn for_current_ledger_obj() -> Self {
-        Self(PathBuf::new(NestedSource::CurrentLedgerObj))
+        Self(LedgerPath::new(LedgerSource::Current))
     }
 
     /// Root a new builder at the ledger object cached in `slot`. Callers reach this through
     /// [`LedgerObjectCommonFields::path`](crate::objects::traits::LedgerObjectCommonFields::path).
     pub(crate) fn for_ledger_obj(slot: i32) -> Self {
-        Self(PathBuf::new(NestedSource::LedgerObj(slot)))
+        Self(LedgerPath::new(LedgerSource::Slot(slot)))
     }
 
     /// Append a field code to the path. See [`TxPathBuilder::field`].
@@ -311,14 +421,21 @@ impl LedgerPathBuilder {
     }
 
     /// Append an array slot index to the path (e.g. the `0` in `SignerEntries[0]`).
+    ///
+    /// Locator segments are `i32`, so an index above [`i32::MAX`] would pack as a negative value the
+    /// host would read back as a field code. Rather than encode that, the path is marked malformed
+    /// and the terminals report [`host::Error::LocatorMalformed`].
     pub fn index(self, index: u32) -> Self {
-        Self(self.0.push(index as i32))
+        match i32::try_from(index) {
+            Ok(index) => Self(self.0.push(index)),
+            Err(_) => Self(self.0.mark_malformed()),
+        }
     }
 
     /// Execute the ledger-object nested-field host call for the built path and decode as `T`.
     ///
     /// `T` must be readable from a ledger object, hence the [`FromLedger`] bound. Returns
-    /// [`host::Error::LocatorMalformed`] without calling the host if the path overflowed.
+    /// [`host::Error::LocatorMalformed`] without calling the host if the path is malformed.
     pub fn get<T: FromLedger>(&self) -> Result<T> {
         self.0.get::<T>()
     }
@@ -326,8 +443,24 @@ impl LedgerPathBuilder {
     /// Like [`get`](Self::get) but treats an absent field as `Ok(None)` rather than an error —
     /// the nested-path counterpart to
     /// [`get_field_optional`](crate::fields::ledger_obj::get_field_optional).
+    ///
+    /// Only reports absence for fields the host signals with `FieldNotFound`. Variable-length
+    /// fields (the `Blob<N>` family) are instead reported as a zero-byte write, so an absent one
+    /// yields `Ok(Some(blob))` with `blob.len == 0` rather than `Ok(None)` — the same distinction
+    /// [`ledger_obj::get_blob_field_optional`](crate::fields::ledger_obj::get_blob_field_optional)
+    /// exists to handle for flat fields.
     pub fn get_optional<T: FromLedger>(&self) -> Result<Option<T>> {
         self.0.get_optional::<T>()
+    }
+
+    /// Ask the host how many entries the array at this path holds, so it can be iterated.
+    ///
+    /// Named `array_len` rather than `len` because [`Locator::len`] already means "bytes packed into
+    /// the path"; this is the length of the array the path points *at*. Returns `Ok(0)` for a
+    /// present-but-empty array, and [`host::Error::LocatorMalformed`] without calling the host if
+    /// the path is malformed.
+    pub fn array_len(&self) -> Result<u32> {
+        self.0.array_len()
     }
 }
 
@@ -467,14 +600,14 @@ mod tests {
 
     /// The bytes a `TxPathBuilder` has packed so far, for asserting on the encoded path.
     fn packed(builder: &TxPathBuilder) -> &[u8] {
-        &builder.0.locator.buffer[..builder.0.locator.cur_buffer_index]
+        &builder.locator.buffer[..builder.locator.cur_buffer_index]
     }
 
     #[test]
     fn test_tx_field_encodes_single_field_code() {
         let builder = TxPathBuilder::for_current_tx().field(sfield::Sequence);
 
-        assert!(!builder.0.overflowed);
+        assert!(!builder.overflowed);
         assert_eq!(packed(&builder), &i32::from(sfield::Sequence).to_le_bytes());
     }
 
@@ -484,7 +617,7 @@ mod tests {
             .field(sfield::Memos)
             .field(sfield::MemoData);
 
-        assert!(!builder.0.overflowed);
+        assert!(!builder.overflowed);
         let bytes = packed(&builder);
         assert_eq!(bytes.len(), 8);
         assert_eq!(&bytes[0..4], &i32::from(sfield::Memos).to_le_bytes());
@@ -499,7 +632,7 @@ mod tests {
             .index(2)
             .field(sfield::MemoType);
 
-        assert!(!builder.0.overflowed);
+        assert!(!builder.overflowed);
         let bytes = packed(&builder);
         assert_eq!(bytes.len(), 12);
         assert_eq!(&bytes[0..4], &i32::from(sfield::Memos).to_le_bytes());
@@ -514,13 +647,13 @@ mod tests {
         for i in 0..16 {
             builder = builder.index(i);
         }
-        assert!(!builder.0.overflowed);
-        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
+        assert!(!builder.overflowed);
+        assert_eq!(builder.locator.num_packed_bytes(), 64);
 
         let builder = builder.field(sfield::Sequence);
-        assert!(builder.0.overflowed);
+        assert!(builder.overflowed);
         // The buffer is not grown or partially overwritten past its capacity.
-        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
+        assert_eq!(builder.locator.num_packed_bytes(), 64);
     }
 
     #[test]
@@ -530,12 +663,12 @@ mod tests {
         for _ in 0..16 {
             builder = builder.field(sfield::Sequence);
         }
-        assert!(!builder.0.overflowed);
-        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
+        assert!(!builder.overflowed);
+        assert_eq!(builder.locator.num_packed_bytes(), 64);
 
         let builder = builder.index(99);
-        assert!(builder.0.overflowed);
-        assert_eq!(builder.0.locator.num_packed_bytes(), 64);
+        assert!(builder.overflowed);
+        assert_eq!(builder.locator.num_packed_bytes(), 64);
     }
 
     #[test]
@@ -568,7 +701,7 @@ mod tests {
         for i in 0..17 {
             builder = builder.index(i);
         }
-        assert!(builder.0.overflowed);
+        assert!(builder.overflowed);
 
         let result = builder.get::<u32>();
         assert!(result.is_err());
@@ -795,5 +928,151 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_ledger_index_past_i32_max_marks_path_malformed_without_calling_host() {
+        // Packing `u32::MAX as i32` would encode -1, which the host would read back as a field
+        // code. The path must be rejected instead of quietly pointing somewhere else.
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_nested_field().times(0);
+        mock.expect_get_ledger_obj_nested_array_len().times(0);
+        let _guard = setup_mock(mock);
+
+        let builder = LedgerPathBuilder::for_ledger_obj(1)
+            .field(sfield::SignerEntries)
+            .index(u32::MAX);
+
+        assert!(builder.0.overflowed);
+        // The out-of-range segment is not encoded at all, so only `SignerEntries` is packed.
+        assert_eq!(builder.0.locator.num_packed_bytes(), 4);
+        assert_eq!(
+            builder.get::<u32>().err().unwrap().code(),
+            host::Error::LocatorMalformed.code()
+        );
+        assert_eq!(
+            builder.array_len().err().unwrap().code(),
+            host::Error::LocatorMalformed.code()
+        );
+    }
+
+    // ---- `array_len()` terminal ----
+
+    #[test]
+    fn test_array_len_current_obj_returns_count() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_current_ledger_obj_nested_array_len()
+            .with(always(), eq(4usize))
+            .times(1)
+            .returning(|_, _| 3);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_current_ledger_obj()
+            .field(sfield::SignerEntries)
+            .array_len();
+
+        assert_eq!(result.unwrap(), 3);
+    }
+
+    #[test]
+    fn test_array_len_by_slot_passes_slot_and_returns_count() {
+        const SLOT: i32 = 4;
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_nested_array_len()
+            .with(eq(SLOT), always(), eq(4usize))
+            .times(1)
+            .returning(|_, _, _| 2);
+        mock.expect_get_current_ledger_obj_nested_array_len()
+            .times(0);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_ledger_obj(SLOT)
+            .field(sfield::PriceDataSeries)
+            .array_len();
+
+        assert_eq!(result.unwrap(), 2);
+    }
+
+    #[test]
+    fn test_array_len_zero_is_ok_not_an_error() {
+        // An array that is present but empty is a legitimate answer.
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_current_ledger_obj_nested_array_len()
+            .times(1)
+            .returning(|_, _| 0);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_current_ledger_obj()
+            .field(sfield::SignerEntries)
+            .array_len();
+
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
+    fn test_array_len_propagates_host_error() {
+        use crate::host::error_codes::INTERNAL_ERROR;
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_current_ledger_obj_nested_array_len()
+            .times(1)
+            .returning(|_, _| INTERNAL_ERROR);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerPathBuilder::for_current_ledger_obj()
+            .field(sfield::SignerEntries)
+            .array_len();
+
+        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn test_array_len_returns_locator_malformed_when_overflowed_without_calling_host() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_nested_array_len().times(0);
+        let _guard = setup_mock(mock);
+
+        let mut builder = LedgerPathBuilder::for_ledger_obj(1);
+        for i in 0..17 {
+            builder = builder.index(i);
+        }
+
+        assert_eq!(
+            builder.array_len().err().unwrap().code(),
+            host::Error::LocatorMalformed.code()
+        );
+    }
+
+    #[test]
+    fn test_array_len_then_index_walks_every_entry() {
+        // The pattern `array_len()` exists for: count, then read each element.
+        const SLOT: i32 = 6;
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_nested_array_len()
+            .with(eq(SLOT), always(), eq(4usize))
+            .times(1)
+            .returning(|_, _, _| 2);
+        // Two reads of PriceDataSeries[i].AssetPrice -> 12 bytes of path, 8-byte u64 buffer.
+        mock.expect_get_ledger_obj_nested_field()
+            .with(eq(SLOT), always(), eq(12usize), always(), eq(8usize))
+            .times(2)
+            .returning(|_, _, _, _, _| 8);
+        let _guard = setup_mock(mock);
+
+        let obj = LedgerPathBuilder::for_ledger_obj(SLOT);
+        let count = obj
+            .clone()
+            .field(sfield::PriceDataSeries)
+            .array_len()
+            .unwrap();
+        assert_eq!(count, 2);
+        for i in 0..count {
+            let price = obj
+                .clone()
+                .field(sfield::PriceDataSeries)
+                .index(i)
+                .field(sfield::AssetPrice)
+                .get::<u64>();
+            assert!(price.is_ok());
+        }
     }
 }

--- a/xrpl-common-stdlib/src/objects/any_object.rs
+++ b/xrpl-common-stdlib/src/objects/any_object.rs
@@ -1,0 +1,99 @@
+//! Untyped handle to a slot-cached ledger object.
+//!
+//! Typed wrappers like [`AccountRoot`](crate::objects::account_root::AccountRoot) exist to add
+//! object-specific named accessors (`AccountFields`, `EscrowFields`). Object types that have no such
+//! wrapper — Oracle, SignerList, NFTokenPage, RippleState — still need the common fields and, above
+//! all, nested-field paths. [`LedgerObject`] is that door: wrap the raw slot `cache_ledger_obj`
+//! handed back and get everything on
+//! [`LedgerObjectCommonFields`](crate::objects::traits::LedgerObjectCommonFields), including
+//! [`path()`](crate::objects::traits::LedgerObjectCommonFields::path).
+//!
+//! Adding a typed wrapper for an object later is purely additive — code written against
+//! `LedgerObject` keeps working.
+
+use crate::objects::traits::LedgerObjectCommonFields;
+
+/// A ledger object identified only by the slot it was cached into.
+///
+/// ```no_run
+/// use xrpl_common_stdlib::objects::LedgerObject;
+/// use xrpl_common_stdlib::objects::traits::LedgerObjectCommonFields;
+/// use xrpl_common_stdlib::sfield;
+/// # fn demo(slot: i32) {
+/// // Read PriceDataSeries[0].AssetPrice off an Oracle object, which has no typed wrapper.
+/// let price = LedgerObject::new(slot)
+///     .path()
+///     .field(sfield::PriceDataSeries)
+///     .index(0)
+///     .field(sfield::AssetPrice)
+///     .get::<u64>();
+/// # let _ = price; }
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct LedgerObject {
+    pub slot_num: i32,
+}
+
+impl LedgerObject {
+    /// Wrap a slot returned by `cache_ledger_obj`.
+    ///
+    /// The slot is not validated here — a negative slot means the caching call failed, and the
+    /// caller is expected to have checked that before building a handle. Field reads through an
+    /// invalid slot surface the host's error as usual.
+    pub fn new(slot_num: i32) -> Self {
+        Self { slot_num }
+    }
+}
+
+impl LedgerObjectCommonFields for LedgerObject {
+    fn get_slot_num(&self) -> i32 {
+        self.slot_num
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::host_bindings_trait::MockHostBindings;
+    use crate::host::setup_mock;
+    use crate::sfield;
+    use mockall::predicate::{always, eq};
+
+    #[test]
+    fn test_new_stores_slot() {
+        assert_eq!(LedgerObject::new(7).get_slot_num(), 7);
+    }
+
+    #[test]
+    fn test_inherits_common_fields() {
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_field()
+            .with(eq(3), eq(sfield::Flags), always(), eq(4))
+            .times(1)
+            .returning(|_, _, _, _| 4);
+        let _guard = setup_mock(mock);
+
+        assert!(LedgerObject::new(3).get_flags().is_ok());
+    }
+
+    #[test]
+    fn test_path_reads_nested_field_through_its_slot() {
+        // The whole point of this type: a nested read on an object with no typed wrapper.
+        // PriceDataSeries[0].AssetPrice is three 4-byte segments = 12 bytes; u64 buffer is 8.
+        let mut mock = MockHostBindings::new();
+        mock.expect_get_ledger_obj_nested_field()
+            .with(eq(9), always(), eq(12usize), always(), eq(8usize))
+            .times(1)
+            .returning(|_, _, _, _, _| 8);
+        let _guard = setup_mock(mock);
+
+        let result = LedgerObject::new(9)
+            .path()
+            .field(sfield::PriceDataSeries)
+            .index(0)
+            .field(sfield::AssetPrice)
+            .get::<u64>();
+
+        assert!(result.is_ok());
+    }
+}

--- a/xrpl-common-stdlib/src/objects/mod.rs
+++ b/xrpl-common-stdlib/src/objects/mod.rs
@@ -30,6 +30,7 @@
 //! ```
 
 pub mod account_root;
+pub mod any_object;
 pub mod array_object;
 pub mod traits;
 
@@ -38,3 +39,5 @@ pub mod traits;
 pub use crate::fields::current_ledger_obj as current_ledger_object;
 /// Typed field accessors for a ledger object cached into a slot. See [`crate::fields::ledger_obj`].
 pub use crate::fields::ledger_obj as ledger_object;
+/// Untyped handle to a slot-cached ledger object, for object types with no typed wrapper.
+pub use any_object::LedgerObject;

--- a/xrpl-common-stdlib/src/objects/traits.rs
+++ b/xrpl-common-stdlib/src/objects/traits.rs
@@ -2,6 +2,7 @@
 //!
 //! Escrow-specific traits live in the `xrpl-escrow-stdlib` crate.
 
+use crate::fields::locator::LedgerPathBuilder;
 use crate::host::{Error, Result, Result::Err, Result::Ok, get_ledger_obj_field};
 use crate::objects::{current_ledger_object, ledger_object};
 use crate::sfield;
@@ -29,6 +30,28 @@ pub trait LedgerObjectCommonFields {
     ///
     /// The slot number as an i32 value
     fn get_slot_num(&self) -> i32;
+
+    /// Starts a nested-field path rooted at this ledger object, read through its slot.
+    ///
+    /// Use this to reach into arrays and inner objects that the flat getters below can't return
+    /// whole (e.g. `SignerEntries[0].Account`). Chain [`field`](LedgerPathBuilder::field) /
+    /// [`index`](LedgerPathBuilder::index), then [`get::<T>()`](LedgerPathBuilder::get).
+    ///
+    /// ```no_run
+    /// use xrpl_common_stdlib::objects::traits::LedgerObjectCommonFields;
+    /// use xrpl_common_stdlib::sfield;
+    /// use xrpl_common_stdlib::types::account_id::AccountID;
+    /// # fn demo(obj: &impl LedgerObjectCommonFields) {
+    /// let signer = obj.path()
+    ///     .field(sfield::SignerEntries)
+    ///     .index(0)
+    ///     .field(sfield::Account)
+    ///     .get::<AccountID>();
+    /// # let _ = signer; }
+    /// ```
+    fn path(&self) -> LedgerPathBuilder {
+        LedgerPathBuilder::for_ledger_obj(self.get_slot_num())
+    }
 
     /// Retrieves the flags field of the ledger object.
     ///
@@ -64,6 +87,24 @@ pub trait CurrentLedgerObjectCommonFields {
     // NOTE: `get_ledger_index()` is not in this trait because `sfLedgerIndex` is not actually a field on a ledger
     // object (it's a synthetic field that maps to the `index` field, which is the unique ID of an object in the
     // ledger's state tree). See https://github.com/XRPLF/rippled/issues/3649 for more context.
+
+    /// Starts a nested-field path rooted at the current ledger object (no slot).
+    ///
+    /// Use this to reach into arrays and inner objects that the flat getters below can't return
+    /// whole. Chain [`field`](LedgerPathBuilder::field) / [`index`](LedgerPathBuilder::index), then
+    /// [`get::<T>()`](LedgerPathBuilder::get).
+    ///
+    /// ```no_run
+    /// use xrpl_common_stdlib::objects::traits::CurrentLedgerObjectCommonFields;
+    /// use xrpl_common_stdlib::sfield;
+    /// use xrpl_common_stdlib::types::amount::Amount;
+    /// # fn demo(obj: &impl CurrentLedgerObjectCommonFields) {
+    /// let amount = obj.path().field(sfield::Amount).get::<Amount>();
+    /// # let _ = amount; }
+    /// ```
+    fn path(&self) -> LedgerPathBuilder {
+        LedgerPathBuilder::for_current_ledger_obj()
+    }
 
     /// Retrieves the flags field of the current ledger object.
     ///
@@ -469,6 +510,28 @@ mod tests {
 
             assert!(result.is_err());
             assert_eq!(result.err().unwrap().code(), INVALID_FIELD);
+        }
+
+        #[test]
+        fn test_path_roots_a_by_slot_builder() {
+            // `obj.path()` must build against the object's own slot and read through
+            // `get_ledger_obj_nested_field`. SignerEntries[0] is two 4-byte segments = 8 bytes;
+            // the u32 read buffer is 4.
+            let mut mock = MockHostBindings::new();
+            mock.expect_get_ledger_obj_nested_field()
+                .with(eq(1), always(), eq(8usize), always(), eq(4usize))
+                .times(1)
+                .returning(|_, _, _, _, _| 4);
+            let _guard = setup_mock(mock);
+
+            let account = AccountRoot { slot_num: 1 };
+            let result = account
+                .path()
+                .field(sfield::SignerEntries)
+                .index(0)
+                .get::<u32>();
+
+            assert!(result.is_ok());
         }
     }
 
@@ -1016,6 +1079,23 @@ mod tests {
 
             assert!(result.is_err());
             assert_eq!(result.err().unwrap().code(), INVALID_FIELD);
+        }
+
+        #[test]
+        fn test_path_roots_a_current_obj_builder() {
+            // `ctx.escrow().path()` must read through the slot-less
+            // `get_current_ledger_obj_nested_field`.
+            let mut mock = MockHostBindings::new();
+            mock.expect_get_current_ledger_obj_nested_field()
+                .with(always(), eq(4usize), always(), eq(4usize))
+                .times(1)
+                .returning(|_, _, _, _| 4);
+            let _guard = setup_mock(mock);
+
+            let escrow = TestCurrentLedgerObject;
+            let result = escrow.path().field(sfield::Flags).get::<u32>();
+
+            assert!(result.is_ok());
         }
     }
 }

--- a/xrpl-common-stdlib/tests/locator/fail_ledger_get_array_not_readable.rs
+++ b/xrpl-common-stdlib/tests/locator/fail_ledger_get_array_not_readable.rs
@@ -1,0 +1,19 @@
+//! The terminal `.get::<T>()` of the ledger path builder requires `T: FromLedger`. `Array` is an
+//! aggregate placeholder that implements no decoder marker, so asking the builder to decode one
+//! whole is a compile error — you navigate *into* an array with `.field(...).index(...)`, you don't
+//! read it back as a value.
+
+use xrpl_common_stdlib::objects::array_object::Array;
+use xrpl_common_stdlib::objects::traits::LedgerObjectCommonFields;
+use xrpl_common_stdlib::sfield;
+
+struct Obj;
+impl LedgerObjectCommonFields for Obj {
+    fn get_slot_num(&self) -> i32 {
+        0
+    }
+}
+
+fn main() {
+    let _ = Obj.path().field(sfield::SignerEntries).get::<Array>();
+}

--- a/xrpl-common-stdlib/tests/locator/fail_ledger_get_array_not_readable.stderr
+++ b/xrpl-common-stdlib/tests/locator/fail_ledger_get_array_not_readable.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `Array: FromLedger` is not satisfied
+  --> tests/locator/fail_ledger_get_array_not_readable.rs:18:59
+   |
+18 |     let _ = Obj.path().field(sfield::SignerEntries).get::<Array>();
+   |                                                     ---   ^^^^^ the trait `FromLedger` is not implemented for `Array`
+   |                                                     |
+   |                                                     required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `FromLedger`:
+             AccountID
+             Amount
+             Blob<N>
+             Currency
+             Issue
+             UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
+           and $N others
+note: required by a bound in `LedgerPathBuilder::get`
+  --> src/fields/locator.rs
+   |
+   |     pub fn get<T: FromLedger>(&self) -> Result<T> {
+   |                   ^^^^^^^^^^ required by this bound in `LedgerPathBuilder::get`

--- a/xrpl-common-stdlib/tests/locator/fail_ledger_get_from_current_tx_only.rs
+++ b/xrpl-common-stdlib/tests/locator/fail_ledger_get_from_current_tx_only.rs
@@ -1,0 +1,35 @@
+//! `LedgerPathBuilder::get` requires `FromLedger` specifically — not merely a `FieldDecoder`, and
+//! not `FromCurrentTx`. A type that opts only into the transaction context must be rejected at a
+//! ledger path builder's terminal, guarding against the bound being accidentally loosened.
+
+use xrpl_common_stdlib::fields::decoder::{FieldDecoder, FromCurrentTx};
+use xrpl_common_stdlib::objects::traits::LedgerObjectCommonFields;
+use xrpl_common_stdlib::sfield;
+use xrpl_common_stdlib::types::decode_error::DecodeError;
+
+struct Obj;
+impl LedgerObjectCommonFields for Obj {
+    fn get_slot_num(&self) -> i32 {
+        0
+    }
+}
+
+struct TxOnly;
+
+impl FieldDecoder for TxOnly {
+    type Buffer = [u8; 1];
+
+    fn empty_buffer() -> Self::Buffer {
+        [0u8; 1]
+    }
+
+    fn decode(_buf: Self::Buffer, _bytes_written: usize) -> Result<Self, DecodeError> {
+        Ok(TxOnly)
+    }
+}
+
+impl FromCurrentTx for TxOnly {}
+
+fn main() {
+    let _ = Obj.path().field(sfield::Flags).get::<TxOnly>();
+}

--- a/xrpl-common-stdlib/tests/locator/fail_ledger_get_from_current_tx_only.stderr
+++ b/xrpl-common-stdlib/tests/locator/fail_ledger_get_from_current_tx_only.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `TxOnly: FromLedger` is not satisfied
+  --> tests/locator/fail_ledger_get_from_current_tx_only.rs:34:51
+   |
+34 |     let _ = Obj.path().field(sfield::Flags).get::<TxOnly>();
+   |                                             ---   ^^^^^^ the trait `FromLedger` is not implemented for `TxOnly`
+   |                                             |
+   |                                             required by a bound introduced by this call
+   |
+   = help: the following other types implement trait `FromLedger`:
+             AccountID
+             Amount
+             Blob<N>
+             Currency
+             Issue
+             UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
+           and $N others
+note: required by a bound in `LedgerPathBuilder::get`
+  --> src/fields/locator.rs
+   |
+   |     pub fn get<T: FromLedger>(&self) -> Result<T> {
+   |                   ^^^^^^^^^^ required by this bound in `LedgerPathBuilder::get`

--- a/xrpl-common-stdlib/tests/locator_compile_fail.rs
+++ b/xrpl-common-stdlib/tests/locator_compile_fail.rs
@@ -1,9 +1,11 @@
-//! Compile-fail tests for the fluent `ctx.tx().path()` builder ([`TxPathBuilder`]).
+//! Compile-fail tests for the fluent path builders (`ctx.tx().path()` → [`TxPathBuilder`],
+//! `obj.path()` / `ctx.escrow().path()` → [`LedgerPathBuilder`]).
 //!
-//! The terminal `.get::<T>()` is bounded on `T: FromCurrentTx`, so it must reject types that
-//! aren't readable from a transaction — aggregate placeholders (`Array`/`Object`) and types that
-//! only opt into the ledger-object context. Unit tests can exercise the runtime behavior but only
-//! a compile-fail snapshot can prove these misuses don't type-check.
+//! Each terminal `.get::<T>()` is bounded on its context marker (`FromCurrentTx` for the tx
+//! builder, `FromLedger` for the ledger builder), so it must reject types that aren't readable from
+//! that context — aggregate placeholders (`Array`/`Object`) and types that only opt into the other
+//! context. Unit tests can exercise the runtime behavior but only a compile-fail snapshot can prove
+//! these misuses don't type-check.
 //!
 //! Regenerate snapshots with:
 //!   TRYBUILD=overwrite cargo test -p xrpl-common-stdlib --test locator_compile_fail


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

The PR title must follow the Conventional Commits format:
  <type>: <Description>

The description must start with a capital letter.
Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, release, example.
See CONTRIBUTING.md for details.
-->

## High Level Overview of Change

Adds the fluent `Locator` path builder for ledger objects (`LedgerPathBuilder`), reachable from any
ledger object via `obj.path()` / `ctx.escrow().path()`.

Adds locator path for ledger objects as well as a shared path builder

### Context of Change

**The shared core is scoped to the ledger side, unlike #217.** #217 extracted a private `PathBuf`
with a 3-way `NestedSource { Tx, CurrentLedgerObj, LedgerObj }` enum and rewrote `TxPathBuilder` as a
newtype over it. Ported forward as-is, that has two costs the tx side shouldn't pay:

- `TxPathBuilder` grows 80 → 88 bytes (measured), and it is moved by value on every `.field()` /
  `.index()`, up to 16 per path.
- `PathBuf::get::<T>` becomes one monomorphization shared by all three sources, so selecting the host
  function turns into a runtime `match` on a discriminant that is statically known at construction.
  It very likely folds under `lto = true, codegen-units = 1`, but #252 emitted a direct call and this
  would make it depend on the optimizer — on a gas-metered target.

More importantly it weakens an invariant. In #252, "a tx builder reads tx fields" was
*unrepresentable otherwise* — there was one `read`, hard-wired. With a 3-way enum,
`LedgerPathBuilder(PathBuf::new(NestedSource::Tx))` type-checks, and the guarantee degrades to a
convention held by two constructors. The trybuild snapshots don't catch that; they pin the public
bound, which is the part that didn't regress.

So the enum here holds only the two *ledger* sources:

```rust
enum LedgerSource { Current, Slot(i32) }   // no Tx variant exists to select
```
TxPathBuilder is left byte-for-byte as #252 shipped it — 80 bytes, direct get_tx_nested_field,
zero diff to its struct or impl. "A LedgerPathBuilder cannot read a transaction field" is now true
by construction. The two ledger sources genuinely need a runtime discriminant: they share the
FromLedger bound so they must be one public type, and Slot carries runtime state. Two sources ×
two terminals (get and array_len) is what earns the factored-out LedgerPath. Cost is ~35
duplicated lines between the builders, which is the trade I'd rather make than churn just-merged code.

I did consider a trait-parameterized Path<S: NestedSource> that dedups those lines while keeping tx
a ZST with direct dispatch. It can't recover the marker bound at the type level either — Rust has no
associated traits, so T: S::Readable isn't expressible and the bound stays on the public wrapper
in every variant of this design. It buys line count only, which isn't worth a generic + trait
indirection in a no_std stdlib. Worth revisiting if array_len() is later added to
TxPathBuilder, since two terminals × two builders pushes duplication to ~60 lines.

Why LedgerObject exists. LedgerPathBuilder::for_ledger_obj(slot) is pub(crate), so the only
public door is LedgerObjectCommonFields::path() — which needs a type implementing that trait. The
repo has exactly two (AccountRoot, Escrow). The one real consumer of slot-based nested reads is
the oracle example, reading off an Oracle entry, which has no wrapper. Without LedgerObject the
feature ships with no reachable caller and cannot replace the unsafe it exists to replace. Typed
wrappers remain the better choice when you want named accessors; adding one later is purely additive.

Why array_len and not len. Locator::len() already means "bytes packed into the path". This
returns the length of the array the path points at, so the longer name avoids a genuinely ambiguous
call. Returns Ok(0) for a present-but-empty array rather than treating that as an error.

Smaller fixes. index() now rejects values above i32::MAX instead of packing them as a negative
the host would read back as a field code. The get_optional rustdoc documents a pre-existing gap
inherited from #252: variable-length fields are reported as a zero-byte write rather than
FieldNotFound, so an absent Blob<N> yields Ok(Some(blob)) with len == 0, never Ok(None) —
the same distinction ledger_obj::get_blob_field_optional exists to handle. Fixing that needs a
blob-aware terminal applied uniformly across both builders and both crates, so it's deferred rather
than half-done here.

### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [x] Tests (added tests for existing code, or tests for the new feature in this PR)
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [ ] Release

<!--
## Test Plan
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
