### PR TITLE
refactor: Host function errors and trace functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ fn run(_ctx: EscrowFinishContext) -> FinishResult {
 
 The `Cargo.toml` must set `crate-type = ["cdylib"]` and depend on `xrpl-common-stdlib`, `xrpl-macros`, and `xrpl-escrow-stdlib` as separate path dependencies. New examples must be added to `examples/Cargo.toml`'s `[workspace] members`.
 
-Trace output (`trace`, `trace_data`, `trace_num`) shows up in rippled's `debug.log`.
+Trace output (`trace`, `trace_hex`, `trace_num`) shows up in rippled's `debug.log`.
 
 ## Integration test pattern
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ use xrpl_macros::smart_escrow;
 
 #[smart_escrow]
 fn run(_ctx: EscrowFinishContext) -> FinishResult {
-    let _ = trace("Hello World");
+    trace("Hello World");
     FinishResult::succeed()
 }
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ cargo build --target wasm32v1-none --release
 These debugging statements will show up in the `debug.log` for rippled.
 
 ```rust
-use xrpl_common_stdlib::host::trace::{trace, trace_data, DataRepr};
+use xrpl_common_stdlib::host::trace::{trace, trace_hex};
 
 #[smart_escrow]
 fn finish_impl(ctx: EscrowFinishContext) -> FinishResult {
@@ -132,7 +132,7 @@ fn finish_impl(ctx: EscrowFinishContext) -> FinishResult {
 
     let account = match ctx.tx().get_account() {
         Ok(acc) => {
-            trace_data("Account", &acc.0, DataRepr::AsHex);
+            trace_hex("Account", &acc.0);
             acc
         },
         Err(e) => {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,11 +128,11 @@ use xrpl_common_stdlib::host::trace::{trace, trace_data, DataRepr};
 
 #[smart_escrow]
 fn finish_impl(ctx: EscrowFinishContext) -> FinishResult {
-    trace("Contract starting").ok();
+    trace("Contract starting");
 
     let account = match ctx.tx().get_account() {
         Ok(acc) => {
-            trace_data("Account", &acc.0, DataRepr::AsHex).ok();
+            trace_data("Account", &acc.0, DataRepr::AsHex);
             acc
         },
         Err(e) => {

--- a/docs/comprehensive-guide.md
+++ b/docs/comprehensive-guide.md
@@ -767,7 +767,7 @@ let len2 = unsafe { tx_field(sfield::Destination, buffer[20..40].as_mut_ptr(), 2
 **Add trace statements:**
 
 ```rust ignore
-use xrpl_common_stdlib::host::trace::{trace, trace_data, trace_num, DataRepr};
+use xrpl_common_stdlib::host::trace::{trace, trace_hex, trace_num};
 use xrpl_escrow_stdlib::current_tx::escrow_finish::EscrowFinish;
 use xrpl_common_stdlib::current_tx::traits::TransactionCommonFields;
 use xrpl_common_stdlib::host::Result::{Ok, Err};
@@ -780,7 +780,7 @@ fn finish_impl(ctx: EscrowFinishContext) -> FinishResult {
 
     let account = match ctx.tx().get_account() {
         Ok(acc) => {
-            trace_data("Account", &acc.0, DataRepr::AsHex);
+            trace_hex("Account", &acc.0);
             acc
         },
         Err(e) => {

--- a/docs/comprehensive-guide.md
+++ b/docs/comprehensive-guide.md
@@ -499,7 +499,7 @@ use xrpl_common_stdlib::host::trace::trace_num;
 
 let result = unsafe { some_host_function(params) };
 if result < 0 {
-    let _ = trace_num("Host function failed with error:", result as i64);
+    trace_num("Host function failed with error:", result as i64);
     return result; // or handle appropriately
 }
 ```
@@ -776,15 +776,15 @@ use xrpl_macros::smart_escrow;
 
 #[smart_escrow]
 fn finish_impl(ctx: EscrowFinishContext) -> FinishResult {
-    trace("Contract starting").ok();
+    trace("Contract starting");
 
     let account = match ctx.tx().get_account() {
         Ok(acc) => {
-            trace_data("Account", &acc.0, DataRepr::AsHex).ok();
+            trace_data("Account", &acc.0, DataRepr::AsHex);
             acc
         },
         Err(e) => {
-            let _ = trace_num("Error getting account, code:", e.code() as i64);
+            trace_num("Error getting account, code:", e.code() as i64);
             return e.code().into();
         }
     };

--- a/e2e-tests/float_tests/src/lib.rs
+++ b/e2e-tests/float_tests/src/lib.rs
@@ -18,7 +18,7 @@ use xrpl_common_stdlib::sfield;
 use xrpl_common_stdlib::types::iou_number::{FLOAT_NEGATIVE_ONE, FLOAT_ONE};
 
 fn test_float_from_host() {
-    let _ = trace("\n$$$ test_float_from_host $$$");
+    trace("\n$$$ test_float_from_host $$$");
 
     let id =
         decode_hex_32(b"97DD92D4F3A791254A530BA769F6669DEBF6B2FC8CCA46842B9031ADCD4D1ADA").unwrap();
@@ -33,7 +33,7 @@ fn test_float_from_host() {
         )
     };
     let f_lptokenbalance: [u8; 8] = buf[0..8].try_into().unwrap();
-    let _ = trace_float("  LPTokenBalance value:", &f_lptokenbalance);
+    trace_float("  LPTokenBalance value:", &f_lptokenbalance);
 
     let mut locator = Locator::new();
     locator.pack(sfield::AuctionSlot);
@@ -48,7 +48,7 @@ fn test_float_from_host() {
         )
     };
     let f_auctionslot: [u8; 8] = buf[0..8].try_into().unwrap();
-    let _ = trace_float("  AuctionSlot Price value:", &f_auctionslot);
+    trace_float("  AuctionSlot Price value:", &f_auctionslot);
 
     let id =
         decode_hex_32(b"D0A063DEE0B0EC9522CF35CD55771B5DCAFA19A133EE46A0295E4D089AF86438").unwrap();
@@ -57,18 +57,18 @@ fn test_float_from_host() {
     let output_len =
         unsafe { le_field(slot, sfield::TakerPays.into(), buf.as_mut_ptr(), buf.len()) };
     let f_takerpays: [u8; 8] = buf[0..8].try_into().unwrap();
-    let _ = trace_float("  TakerPays:", &f_takerpays);
+    trace_float("  TakerPays:", &f_takerpays);
 }
 
 fn test_float_from_wasm() {
-    let _ = trace("\n$$$ test_float_from_wasm $$$");
+    trace("\n$$$ test_float_from_wasm $$$");
 
     let mut f: [u8; 8] = [0u8; 8];
     if 8 == unsafe { float_from_int(12300, f.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) } {
-        let _ = trace_float("  float from i64 12300:", &f);
-        let _ = trace_data("  float from i64 12300 as HEX:", &f, AsHex);
+        trace_float("  float from i64 12300:", &f);
+        trace_data("  float from i64 12300 as HEX:", &f, AsHex);
     } else {
-        let _ = trace("  float from i64 12300: failed");
+        trace("  float from i64 12300: failed");
     }
 
     let u64_value: u64 = 12300;
@@ -81,54 +81,54 @@ fn test_float_from_wasm() {
             RoundingMode::ToNearest.into(),
         )
     } {
-        let _ = trace_float("  float from u64 12300:", &f);
+        trace_float("  float from u64 12300:", &f);
     } else {
-        let _ = trace("  float from u64 12300: failed");
+        trace("  float from u64 12300: failed");
     }
 
     if 8 == unsafe {
         float_from_mant_exp(123, 2, f.as_mut_ptr(), 8, RoundingMode::ToNearest.into())
     } {
-        let _ = trace_float("  float from exp 2, mantissa 123:", &f);
+        trace_float("  float from exp 2, mantissa 123:", &f);
     } else {
-        let _ = trace("  float from exp 2, mantissa 3: failed");
+        trace("  float from exp 2, mantissa 3: failed");
     }
 
-    let _ = trace_float("  float from const 1:", &FLOAT_ONE);
-    let _ = trace_float("  float from const -1:", &FLOAT_NEGATIVE_ONE);
+    trace_float("  float from const 1:", &FLOAT_ONE);
+    trace_float("  float from const -1:", &FLOAT_NEGATIVE_ONE);
 }
 
 fn test_float_cmp() {
-    let _ = trace("\n$$$ test_float_cmp $$$");
+    trace("\n$$$ test_float_cmp $$$");
 
     let mut f1: [u8; 8] = [0u8; 8];
     if 8 != unsafe { float_from_int(1, f1.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) } {
-        let _ = trace("  float from 1: failed");
+        trace("  float from 1: failed");
     } else {
-        let _ = trace_float("  float from 1:", &f1);
+        trace_float("  float from 1:", &f1);
     }
 
     if 0 == unsafe { float_cmp(f1.as_ptr(), 8, FLOAT_ONE.as_ptr(), 8) } {
-        let _ = trace("  float from 1 == FLOAT_ONE");
+        trace("  float from 1 == FLOAT_ONE");
     } else {
-        let _ = trace("  float from 1 != FLOAT_ONE");
+        trace("  float from 1 != FLOAT_ONE");
     }
 
     if 1 == unsafe { float_cmp(f1.as_ptr(), 8, FLOAT_NEGATIVE_ONE.as_ptr(), 8) } {
-        let _ = trace("  float from 1 > FLOAT_NEGATIVE_ONE");
+        trace("  float from 1 > FLOAT_NEGATIVE_ONE");
     } else {
-        let _ = trace("  float from 1 !> FLOAT_NEGATIVE_ONE");
+        trace("  float from 1 !> FLOAT_NEGATIVE_ONE");
     }
 
     if 2 == unsafe { float_cmp(FLOAT_NEGATIVE_ONE.as_ptr(), 8, f1.as_ptr(), 8) } {
-        let _ = trace("  FLOAT_NEGATIVE_ONE < float from 1");
+        trace("  FLOAT_NEGATIVE_ONE < float from 1");
     } else {
-        let _ = trace("  FLOAT_NEGATIVE_ONE !< float from 1");
+        trace("  FLOAT_NEGATIVE_ONE !< float from 1");
     }
 }
 
 fn test_float_add_subtract() {
-    let _ = trace("\n$$$ test_float_add_subtract $$$");
+    trace("\n$$$ test_float_add_subtract $$$");
 
     let mut f_compute: [u8; 8] = FLOAT_ONE;
     for i in 0..9 {
@@ -143,16 +143,16 @@ fn test_float_add_subtract() {
                 RoundingMode::ToNearest.into(),
             )
         };
-        // let _ = trace_float("  float:", &f_compute);
+        // trace_float("  float:", &f_compute);
     }
     let mut f10: [u8; 8] = [0u8; 8];
     if 8 != unsafe { float_from_int(10, f10.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) } {
-        // let _ = trace("  float from 10: failed");
+        // trace("  float from 10: failed");
     }
     if 0 == unsafe { float_cmp(f10.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  repeated add: good");
+        trace("  repeated add: good");
     } else {
-        let _ = trace("  repeated add: bad");
+        trace("  repeated add: bad");
     }
 
     for i in 0..11 {
@@ -169,14 +169,14 @@ fn test_float_add_subtract() {
         };
     }
     if 0 == unsafe { float_cmp(f_compute.as_ptr(), 8, FLOAT_NEGATIVE_ONE.as_ptr(), 8) } {
-        let _ = trace("  repeated subtract: good");
+        trace("  repeated subtract: good");
     } else {
-        let _ = trace("  repeated subtract: bad");
+        trace("  repeated subtract: bad");
     }
 }
 
 fn test_float_mult_divide() {
-    let _ = trace("\n$$$ test_float_mult_divide $$$");
+    trace("\n$$$ test_float_mult_divide $$$");
 
     let mut f10: [u8; 8] = [0u8; 8];
     unsafe { float_from_int(10, f10.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) };
@@ -193,7 +193,7 @@ fn test_float_mult_divide() {
                 RoundingMode::ToNearest.into(),
             )
         };
-        // let _ = trace_float("  float:", &f_compute);
+        // trace_float("  float:", &f_compute);
     }
     let mut f1000000: [u8; 8] = [0u8; 8];
     unsafe {
@@ -206,9 +206,9 @@ fn test_float_mult_divide() {
     };
 
     if 0 == unsafe { float_cmp(f1000000.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  repeated multiply: good");
+        trace("  repeated multiply: good");
     } else {
-        let _ = trace("  repeated multiply: bad");
+        trace("  repeated multiply: bad");
     }
 
     for i in 0..7 {
@@ -228,14 +228,14 @@ fn test_float_mult_divide() {
     unsafe { float_from_mant_exp(1, -1, f01.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) };
 
     if 0 == unsafe { float_cmp(f_compute.as_ptr(), 8, f01.as_ptr(), 8) } {
-        let _ = trace("  repeated divide: good");
+        trace("  repeated divide: good");
     } else {
-        let _ = trace("  repeated divide: bad");
+        trace("  repeated divide: bad");
     }
 }
 
 fn test_float_pow() {
-    let _ = trace("\n$$$ test_float_pow $$$");
+    trace("\n$$$ test_float_pow $$$");
 
     let mut f_compute: [u8; 8] = [0u8; 8];
     unsafe {
@@ -248,7 +248,7 @@ fn test_float_pow() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float cube of 1:", &f_compute);
+    trace_float("  float cube of 1:", &f_compute);
 
     unsafe {
         float_pow(
@@ -260,7 +260,7 @@ fn test_float_pow() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float 6th power of -1:", &f_compute);
+    trace_float("  float 6th power of -1:", &f_compute);
 
     let mut f9: [u8; 8] = [0u8; 8];
     unsafe { float_from_int(9, f9.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) };
@@ -274,7 +274,7 @@ fn test_float_pow() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float square of 9:", &f_compute);
+    trace_float("  float square of 9:", &f_compute);
 
     unsafe {
         float_pow(
@@ -286,7 +286,7 @@ fn test_float_pow() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float 0th power of 9:", &f_compute);
+    trace_float("  float 0th power of 9:", &f_compute);
 
     let mut f0: [u8; 8] = [0u8; 8];
     unsafe { float_from_int(0, f0.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) };
@@ -300,7 +300,7 @@ fn test_float_pow() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float square of 0:", &f_compute);
+    trace_float("  float square of 0:", &f_compute);
 
     let r = unsafe {
         float_pow(
@@ -312,14 +312,14 @@ fn test_float_pow() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_num(
+    trace_num(
         "  float 0th power of 0 (expecting INVALID_PARAMS error):",
         r as i64,
     );
 }
 
 fn test_float_root() {
-    let _ = trace("\n$$$ test_float_root $$$");
+    trace("\n$$$ test_float_root $$$");
 
     let mut f9: [u8; 8] = [0u8; 8];
     unsafe { float_from_int(9, f9.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) };
@@ -334,7 +334,7 @@ fn test_float_root() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float sqrt of 9:", &f_compute);
+    trace_float("  float sqrt of 9:", &f_compute);
     unsafe {
         float_root(
             f9.as_ptr(),
@@ -345,7 +345,7 @@ fn test_float_root() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float cbrt of 9:", &f_compute);
+    trace_float("  float cbrt of 9:", &f_compute);
 
     let mut f1000000: [u8; 8] = [0u8; 8];
     unsafe {
@@ -366,7 +366,7 @@ fn test_float_root() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float cbrt of 1000000:", &f_compute);
+    trace_float("  float cbrt of 1000000:", &f_compute);
     unsafe {
         float_root(
             f1000000.as_ptr(),
@@ -377,11 +377,11 @@ fn test_float_root() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  float 6th root of 1000000:", &f_compute);
+    trace_float("  float 6th root of 1000000:", &f_compute);
 }
 
 fn test_float_negate() {
-    let _ = trace("\n$$$ test_float_negate $$$");
+    trace("\n$$$ test_float_negate $$$");
 
     let mut f_compute: [u8; 8] = [0u8; 8];
     unsafe {
@@ -395,11 +395,11 @@ fn test_float_negate() {
             RoundingMode::ToNearest.into(),
         )
     };
-    // let _ = trace_float("  float:", &f_compute);
+    // trace_float("  float:", &f_compute);
     if 0 == unsafe { float_cmp(FLOAT_NEGATIVE_ONE.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  negate const 1: good");
+        trace("  negate const 1: good");
     } else {
-        let _ = trace("  negate const 1: bad");
+        trace("  negate const 1: bad");
     }
 
     unsafe {
@@ -413,16 +413,16 @@ fn test_float_negate() {
             RoundingMode::ToNearest.into(),
         )
     };
-    // let _ = trace_float("  float:", &f_compute);
+    // trace_float("  float:", &f_compute);
     if 0 == unsafe { float_cmp(FLOAT_ONE.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  negate const -1: good");
+        trace("  negate const -1: good");
     } else {
-        let _ = trace("  negate const -1: bad");
+        trace("  negate const -1: bad");
     }
 }
 
 fn test_float_invert() {
-    let _ = trace("\n$$$ test_float_invert $$$");
+    trace("\n$$$ test_float_invert $$$");
 
     let mut f_compute: [u8; 8] = [0u8; 8];
     let mut f10: [u8; 8] = [0u8; 8];
@@ -438,7 +438,7 @@ fn test_float_invert() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  invert a float from 10:", &f_compute);
+    trace_float("  invert a float from 10:", &f_compute);
     unsafe {
         float_div(
             FLOAT_ONE.as_ptr(),
@@ -450,13 +450,13 @@ fn test_float_invert() {
             RoundingMode::ToNearest.into(),
         )
     };
-    let _ = trace_float("  invert again:", &f_compute);
+    trace_float("  invert again:", &f_compute);
 
     // if f10's value is 7, then invert twice won't match the original value
     if 0 == unsafe { float_cmp(f10.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  invert twice: good");
+        trace("  invert twice: good");
     } else {
-        let _ = trace("  invert twice: bad");
+        trace("  invert twice: bad");
     }
 }
 

--- a/e2e-tests/float_tests/src/lib.rs
+++ b/e2e-tests/float_tests/src/lib.rs
@@ -7,12 +7,10 @@ extern crate std;
 
 use xrpl_common_stdlib::decode_hex_32;
 use xrpl_common_stdlib::fields::locator::Locator;
-use xrpl_common_stdlib::host::trace::DataRepr::AsHex;
-use xrpl_common_stdlib::host::trace::{DataRepr, trace, trace_data, trace_float, trace_num};
+use xrpl_common_stdlib::host::trace::{trace, trace_float, trace_hex, trace_num};
 use xrpl_common_stdlib::host::{
     RoundingMode, cache_le, float_add, float_cmp, float_div, float_from_int, float_from_mant_exp,
     float_from_uint, float_mult, float_pow, float_root, float_sub, le_arr_len, le_field, le_inner,
-    trace_xfloat,
 };
 use xrpl_common_stdlib::sfield;
 use xrpl_common_stdlib::types::iou_number::{FLOAT_NEGATIVE_ONE, FLOAT_ONE};
@@ -66,7 +64,7 @@ fn test_float_from_wasm() {
     let mut f: [u8; 8] = [0u8; 8];
     if 8 == unsafe { float_from_int(12300, f.as_mut_ptr(), 8, RoundingMode::ToNearest.into()) } {
         trace_float("  float from i64 12300:", &f);
-        trace_data("  float from i64 12300 as HEX:", &f, AsHex);
+        trace_hex("  float from i64 12300 as HEX:", &f);
     } else {
         trace("  float from i64 12300: failed");
     }

--- a/e2e-tests/gas_benchmark/README.md
+++ b/e2e-tests/gas_benchmark/README.md
@@ -62,7 +62,7 @@ fn benchmark_my_new_function() -> u64 {
 Add a call in the `finish()` function:
 
 ```rust
-let _ = trace("BENCHMARK: my_new_function");
+trace("BENCHMARK: my_new_function");
 accumulator = accumulator.wrapping_add(benchmark_my_new_function());
 ```
 

--- a/e2e-tests/gas_benchmark/src/lib.rs
+++ b/e2e-tests/gas_benchmark/src/lib.rs
@@ -33,7 +33,7 @@ const ITERATIONS: usize = 100;
 /// - Hex decoding (decode_hex_32, decode_hex_20)
 #[unsafe(no_mangle)]
 pub extern "C" fn escrow_finish() -> i32 {
-    let _ = trace("$$$$$ GAS BENCHMARK START $$$$$");
+    trace("$$$$$ GAS BENCHMARK START $$$$$");
 
     // Get the current transaction
     let escrow_finish: EscrowFinish = get_current_escrow_finish();
@@ -43,90 +43,90 @@ pub extern "C" fn escrow_finish() -> i32 {
     let mut accumulator: u64 = 0;
 
     // Locator operation benchmarks
-    let _ = trace("BENCHMARK_SECTION: LOCATOR_OPERATIONS");
-    let _ = trace("BENCHMARK: locator_pack_single");
+    trace("BENCHMARK_SECTION: LOCATOR_OPERATIONS");
+    trace("BENCHMARK: locator_pack_single");
     accumulator = accumulator.wrapping_add(benchmark_locator_pack_single());
 
-    let _ = trace("BENCHMARK: locator_pack_inner");
+    trace("BENCHMARK: locator_pack_inner");
     accumulator = accumulator.wrapping_add(benchmark_locator_pack_inner());
 
-    let _ = trace("BENCHMARK: locator_repack_last");
+    trace("BENCHMARK: locator_repack_last");
     accumulator = accumulator.wrapping_add(benchmark_locator_repack_last());
 
     // Transaction field access benchmarks
-    let _ = trace("BENCHMARK_SECTION: TRANSACTION_FIELD_ACCESS");
-    let _ = trace("BENCHMARK: get_account_id_field");
+    trace("BENCHMARK_SECTION: TRANSACTION_FIELD_ACCESS");
+    trace("BENCHMARK: get_account_id_field");
     accumulator = accumulator.wrapping_add(benchmark_account_id_field(&escrow_finish));
 
-    let _ = trace("BENCHMARK: get_fee_field");
+    trace("BENCHMARK: get_fee_field");
     accumulator = accumulator.wrapping_add(benchmark_fee_field(&escrow_finish));
 
-    let _ = trace("BENCHMARK: get_amount_field");
+    trace("BENCHMARK: get_amount_field");
     accumulator = accumulator.wrapping_add(benchmark_amount_field(&escrow_finish));
 
-    let _ = trace("BENCHMARK: get_hash256_field");
+    trace("BENCHMARK: get_hash256_field");
     accumulator = accumulator.wrapping_add(benchmark_hash256_field(&escrow));
 
-    let _ = trace("BENCHMARK: get_u16_field");
+    trace("BENCHMARK: get_u16_field");
     accumulator = accumulator.wrapping_add(benchmark_u16_field(&escrow_finish));
 
-    let _ = trace("BENCHMARK: get_u64_field");
+    trace("BENCHMARK: get_u64_field");
     accumulator = accumulator.wrapping_add(benchmark_u64_field(&escrow_finish));
 
     // Blob benchmarks
-    let _ = trace("BENCHMARK_SECTION: BLOB_OPERATIONS");
-    let _ = trace("BENCHMARK: blob_creation");
+    trace("BENCHMARK_SECTION: BLOB_OPERATIONS");
+    trace("BENCHMARK: blob_creation");
     accumulator = accumulator.wrapping_add(benchmark_blob_creation());
 
-    let _ = trace("BENCHMARK: blob_field_access");
+    trace("BENCHMARK: blob_field_access");
     accumulator = accumulator.wrapping_add(benchmark_blob_field_access(&escrow_finish));
 
     // Optional field access benchmarks
-    let _ = trace("BENCHMARK_SECTION: OPTIONAL_FIELD_ACCESS");
-    let _ = trace("BENCHMARK: optional_field_some");
+    trace("BENCHMARK_SECTION: OPTIONAL_FIELD_ACCESS");
+    trace("BENCHMARK: optional_field_some");
     accumulator = accumulator.wrapping_add(benchmark_optional_field_some(&escrow_finish));
 
-    let _ = trace("BENCHMARK: optional_field_none");
+    trace("BENCHMARK: optional_field_none");
     accumulator = accumulator.wrapping_add(benchmark_optional_field_none(&escrow_finish));
 
     // Error code matching benchmarks
-    let _ = trace("BENCHMARK_SECTION: ERROR_CODE_MATCHING");
-    let _ = trace("BENCHMARK: match_result_code");
+    trace("BENCHMARK_SECTION: ERROR_CODE_MATCHING");
+    trace("BENCHMARK: match_result_code");
     accumulator = accumulator.wrapping_add(benchmark_match_result_code());
 
-    let _ = trace("BENCHMARK: match_result_code_optional");
+    trace("BENCHMARK: match_result_code_optional");
     accumulator = accumulator.wrapping_add(benchmark_match_result_code_optional());
 
-    let _ = trace("BENCHMARK: match_result_code_with_expected_bytes");
+    trace("BENCHMARK: match_result_code_with_expected_bytes");
     accumulator = accumulator.wrapping_add(benchmark_match_result_code_with_expected_bytes());
 
-    let _ = trace("BENCHMARK: match_result_code_with_expected_bytes_optional");
+    trace("BENCHMARK: match_result_code_with_expected_bytes_optional");
     accumulator =
         accumulator.wrapping_add(benchmark_match_result_code_with_expected_bytes_optional());
 
     // Result type method benchmarks
-    let _ = trace("BENCHMARK_SECTION: RESULT_TYPE_METHODS");
-    let _ = trace("BENCHMARK: is_ok");
+    trace("BENCHMARK_SECTION: RESULT_TYPE_METHODS");
+    trace("BENCHMARK: is_ok");
     accumulator = accumulator.wrapping_add(benchmark_is_ok(&escrow_finish));
 
-    let _ = trace("BENCHMARK: is_err");
+    trace("BENCHMARK: is_err");
     accumulator = accumulator.wrapping_add(benchmark_is_err(&escrow_finish));
 
-    let _ = trace("BENCHMARK: result_ok");
+    trace("BENCHMARK: result_ok");
     accumulator = accumulator.wrapping_add(benchmark_result_ok(&escrow_finish));
 
-    let _ = trace("BENCHMARK: result_err");
+    trace("BENCHMARK: result_err");
     accumulator = accumulator.wrapping_add(benchmark_result_err(&escrow_finish));
 
     // Hex decoding benchmarks
-    let _ = trace("BENCHMARK_SECTION: HEX_DECODING");
-    let _ = trace("BENCHMARK: decode_hex_32");
+    trace("BENCHMARK_SECTION: HEX_DECODING");
+    trace("BENCHMARK: decode_hex_32");
     accumulator = accumulator.wrapping_add(benchmark_decode_hex_32());
 
-    let _ = trace("BENCHMARK: decode_hex_20");
+    trace("BENCHMARK: decode_hex_20");
     accumulator = accumulator.wrapping_add(benchmark_decode_hex_20());
 
-    let _ = trace("$$$$$ GAS BENCHMARK END $$$$$");
+    trace("$$$$$ GAS BENCHMARK END $$$$$");
 
     // Return 1 if accumulator is non-zero (it always will be), preventing optimization
     if accumulator > 0 { 1 } else { 0 }

--- a/e2e-tests/host_functions_test/src/lib.rs
+++ b/e2e-tests/host_functions_test/src/lib.rs
@@ -28,7 +28,7 @@ extern crate std;
 use xrpl_common_stdlib::current_tx::traits::TransactionCommonFields;
 use xrpl_common_stdlib::host;
 use xrpl_common_stdlib::host::trace::{
-    DataRepr, trace, trace_acct_buf, trace_amt, trace_data, trace_num,
+    TraceDataType, trace, trace_acct_buf, trace_amt, trace_hex, trace_num,
 };
 use xrpl_common_stdlib::sfield;
 use xrpl_common_stdlib::types::account_id::AccountID;
@@ -135,7 +135,7 @@ fn test_ledger_header_functions() -> i32 {
         trace_num("ERROR: parent_ldgr_hash wrong length:", hash_result as i64);
         return -103; // Parent ledger hash test failed - should be exactly 32 bytes
     }
-    trace_data("Parent ledger hash:", &hash_buffer, DataRepr::AsHex);
+    trace_hex("Parent ledger hash:", &hash_buffer);
 
     trace("SUCCESS: Ledger header functions");
     0
@@ -182,11 +182,7 @@ fn test_transaction_data_functions() -> i32 {
         return -202; // Fee field test failed - XRP amounts should be exactly 8 bytes
     }
     trace_num("Transaction Fee length:", fee_len as i64);
-    trace_data(
-        "Transaction Fee (serialized XRP amount):",
-        &fee_buffer,
-        DataRepr::AsHex,
-    );
+    trace_hex("Transaction Fee (serialized XRP amount):", &fee_buffer);
 
     // Test with Sequence field (required, 4 bytes uint32)
     let mut seq_buffer = [0u8; 4];
@@ -202,7 +198,7 @@ fn test_transaction_data_functions() -> i32 {
         trace_num("ERROR: tx_field(Sequence) wrong length:", seq_len as i64);
         return -203; // Sequence field test failed
     }
-    trace_data("Transaction Sequence:", &seq_buffer, DataRepr::AsHex);
+    trace_hex("Transaction Sequence:", &seq_buffer);
 
     // NOTE: tx_field2() through tx_field6() have been deprecated.
     // Use tx_field() with appropriate parameters for all transaction field access.
@@ -224,11 +220,7 @@ fn test_transaction_data_functions() -> i32 {
         // Expected - locator may not match transaction structure
     } else {
         trace_num("Inner field length:", inner_result as i64);
-        trace_data(
-            "Inner field:",
-            &inner_buffer[..inner_result as usize],
-            DataRepr::AsHex,
-        );
+        trace_hex("Inner field:", &inner_buffer[..inner_result as usize]);
     }
 
     // Test 2.3: tx_arr_len() - Get array length
@@ -281,20 +273,18 @@ fn test_current_ledger_object_functions() -> i32 {
             "Current object balance length (XRP amount):",
             balance_result as i64,
         );
-        trace_data(
+        trace_hex(
             "Current object balance (serialized XRP amount):",
             &balance_buffer,
-            DataRepr::AsHex,
         );
     } else {
         trace_num(
             "Current object balance length (non-XRP amount):",
             balance_result as i64,
         );
-        trace_data(
+        trace_hex(
             "Current object balance:",
             &balance_buffer[..balance_result as usize],
-            DataRepr::AsHex,
         );
     }
 
@@ -336,10 +326,9 @@ fn test_current_ledger_object_functions() -> i32 {
         );
     } else {
         trace_num("Current inner field length:", current_inner_result as i64);
-        trace_data(
+        trace_hex(
             "Current inner field:",
             &current_inner_buffer[..current_inner_result as usize],
-            DataRepr::AsHex,
         );
     }
 
@@ -488,20 +477,18 @@ fn test_any_ledger_object_functions() -> i32 {
             "Cached object balance length (XRP amount):",
             cached_balance_result as i64,
         );
-        trace_data(
+        trace_hex(
             "Cached object balance (serialized XRP amount):",
             &cached_balance_buffer,
-            DataRepr::AsHex,
         );
     } else {
         trace_num(
             "Cached object balance length (non-XRP amount):",
             cached_balance_result as i64,
         );
-        trace_data(
+        trace_hex(
             "Cached object balance:",
             &cached_balance_buffer[..cached_balance_result as usize],
-            DataRepr::AsHex,
         );
     }
 
@@ -522,10 +509,9 @@ fn test_any_ledger_object_functions() -> i32 {
         trace_num("INFO: le_inner not applicable:", cached_inner_result as i64);
     } else {
         trace_num("Cached inner field length:", cached_inner_result as i64);
-        trace_data(
+        trace_hex(
             "Cached inner field:",
             &cached_inner_buffer[..cached_inner_result as usize],
-            DataRepr::AsHex,
         );
     }
 
@@ -579,11 +565,7 @@ fn test_id_generation_functions() -> i32 {
         );
         return -501; // AccountRoot ledger entry ID generation failed
     }
-    trace_data(
-        "AccountRoot ledger entry ID:",
-        &accountroot_id_buffer,
-        DataRepr::AsHex,
-    );
+    trace_hex("AccountRoot ledger entry ID:", &accountroot_id_buffer);
 
     // Test 5.2: credential_id() - Generate ledger entry ID for credential
     let mut credential_id_buffer = [0u8; 32];
@@ -607,10 +589,9 @@ fn test_id_generation_functions() -> i32 {
         );
         // This is expected to fail due to unusual parameter types
     } else {
-        trace_data(
+        trace_hex(
             "Credential ledger entry ID:",
             &credential_id_buffer[..credential_id_result as usize],
-            DataRepr::AsHex,
         );
     }
 
@@ -633,11 +614,7 @@ fn test_id_generation_functions() -> i32 {
         trace_num("ERROR: escrow_id failed:", escrow_id_result as i64);
         return -503; // Escrow ledger entry ID generation failed
     }
-    trace_data(
-        "Escrow ledger entry ID:",
-        &escrow_id_buffer,
-        DataRepr::AsHex,
-    );
+    trace_hex("Escrow ledger entry ID:", &escrow_id_buffer);
 
     // Test 5.4: oracle_id() - Generate ledger entry ID for oracle
     let mut oracle_id_buffer = [0u8; 32];
@@ -658,11 +635,7 @@ fn test_id_generation_functions() -> i32 {
         trace_num("ERROR: oracle_id failed:", oracle_id_result as i64);
         return -504; // Oracle ledger entry ID generation failed
     }
-    trace_data(
-        "Oracle ledger entry ID:",
-        &oracle_id_buffer,
-        DataRepr::AsHex,
-    );
+    trace_hex("Oracle ledger entry ID:", &oracle_id_buffer);
 
     trace("SUCCESS: LedgerEntryId generation functions");
     0
@@ -689,8 +662,8 @@ fn test_utility_functions() -> i32 {
         trace_num("ERROR: sha512_half failed:", hash_result as i64);
         return -601; // SHA512 half computation failed
     }
-    trace_data("Input data:", test_data, DataRepr::AsHex);
-    trace_data("SHA512 half hash:", &hash_output, DataRepr::AsHex);
+    trace_hex("Input data:", test_data);
+    trace_hex("SHA512 half hash:", &hash_output);
 
     // Test 6.2: nft_uri() - NFT data retrieval
     let escrow_finish = EscrowFinish;
@@ -716,49 +689,26 @@ fn test_utility_functions() -> i32 {
         // This is expected - test account likely doesn't own the dummy NFT
     } else {
         trace_num("NFT data length:", nft_result as i64);
-        trace_data(
-            "NFT data:",
-            &nft_buffer[..nft_result as usize],
-            DataRepr::AsHex,
-        );
+        trace_hex("NFT data:", &nft_buffer[..nft_result as usize]);
     }
 
     // Test 6.3: trace() - Debug logging with data
     let trace_message = b"Test trace message";
     let trace_data_payload = b"payload";
-    let trace_result = unsafe {
+    unsafe {
         host::trace(
             trace_message.as_ptr(),
             trace_message.len(),
+            TraceDataType::AsHex as i32,
             trace_data_payload.as_ptr(),
             trace_data_payload.len(),
-            1, // as_hex = true
         )
     };
 
-    if trace_result < 0 {
-        trace_num("ERROR: trace() failed:", trace_result as i64);
-        return -603; // Trace function failed
-    }
-    trace_num("Trace function bytes written:", trace_result as i64);
-
     // Test 6.4: trace_num() - Debug logging with number
     let test_number = 42i64;
-    let trace_num_result = trace_num("Test number trace", test_number);
-
-    use xrpl_common_stdlib::host::Result;
-    match trace_num_result {
-        Result::Ok(_) => {
-            trace_num("Trace_num function succeeded", 0);
-        }
-        Result::Err(_) => {
-            trace_num(
-                "ERROR: trace_num() failed:",
-                trace_num_result.err().unwrap().code() as i64,
-            );
-            return -604; // Trace number function failed
-        }
-    }
+    trace_num("Test number trace", test_number);
+    trace_num("Trace_num function succeeded", 0);
 
     // Test 6.5: trace_amt() - Debug logging with Amount
     match test_trace_amt_functions() {
@@ -785,11 +735,7 @@ fn test_data_update_functions() -> i32 {
         return -701; // Data update failed
     }
 
-    trace_data(
-        "Successfully updated ledger entry with:",
-        update_payload,
-        DataRepr::AsHex,
-    );
+    trace_hex("Successfully updated ledger entry with:", update_payload);
     trace("SUCCESS: Data update functions");
     1 // <-- Finish the escrow to indicate a successful outcome
 }
@@ -803,37 +749,15 @@ fn test_trace_amt_functions() -> i32 {
     let xrp_amount = Amount::XRP {
         num_drops: 1_000_000, // 1 XRP
     };
-    let trace_result = trace_amt("Test XRP amount (1 XRP)", &xrp_amount);
-    match trace_result {
-        host::Result::Ok(_) => {
-            trace("SUCCESS: trace_amt with positive XRP");
-        }
-        host::Result::Err(_) => {
-            trace_num(
-                "ERROR: trace_amt XRP failed:",
-                trace_result.err().unwrap().code() as i64,
-            );
-            return -605; // Trace amount XRP failed
-        }
-    }
+    trace_amt("Test XRP amount (1 XRP)", &xrp_amount);
+    trace("SUCCESS: trace_amt with positive XRP");
 
     // Test 6.5.2: trace_amt() with negative XRP amount
     let negative_xrp_amount = Amount::XRP {
         num_drops: -500_000, // -0.5 XRP
     };
-    let trace_result = trace_amt("Test negative XRP amount (-0.5 XRP)", &negative_xrp_amount);
-    match trace_result {
-        host::Result::Ok(_) => {
-            trace("SUCCESS: trace_amt with negative XRP");
-        }
-        host::Result::Err(_) => {
-            trace_num(
-                "ERROR: trace_amt negative XRP failed:",
-                trace_result.err().unwrap().code() as i64,
-            );
-            return -606; // Trace amount negative XRP failed
-        }
-    }
+    trace_amt("Test negative XRP amount (-0.5 XRP)", &negative_xrp_amount);
+    trace("SUCCESS: trace_amt with negative XRP");
 
     // Test 6.5.3: trace_amt() with zero XRP amount
     // TODO: uncomment when new devnet is deployed
@@ -854,37 +778,15 @@ fn test_trace_amt_functions() -> i32 {
 
     // Test 6.5.4: trace_amt() with small XRP amount (fee-like)
     let fee_amount = Amount::XRP { num_drops: 10 }; // 10 drops (typical fee)
-    let trace_result = trace_amt("Test small XRP amount (10 drops)", &fee_amount);
-    match trace_result {
-        host::Result::Ok(_) => {
-            trace("SUCCESS: trace_amt with small XRP");
-        }
-        host::Result::Err(_) => {
-            trace_num(
-                "ERROR: trace_amt small XRP failed:",
-                trace_result.err().unwrap().code() as i64,
-            );
-            return -608; // Trace amount small XRP failed
-        }
-    }
+    trace_amt("Test small XRP amount (10 drops)", &fee_amount);
+    trace("SUCCESS: trace_amt with small XRP");
 
     // Test 6.5.5: trace_amt() with large XRP amount
     let large_xrp_amount = Amount::XRP {
         num_drops: 100_000_000_000, // 100,000 XRP
     };
-    let trace_result = trace_amt("Test large XRP amount (100,000 XRP)", &large_xrp_amount);
-    match trace_result {
-        host::Result::Ok(_) => {
-            trace("SUCCESS: trace_amt with large XRP");
-        }
-        host::Result::Err(_) => {
-            trace_num(
-                "ERROR: trace_amt large XRP failed:",
-                trace_result.err().unwrap().code() as i64,
-            );
-            return -609; // Trace amount large XRP failed
-        }
-    }
+    trace_amt("Test large XRP amount (100,000 XRP)", &large_xrp_amount);
+    trace("SUCCESS: trace_amt with large XRP");
 
     trace("SUCCESS: trace_amt XRP tests completed");
 
@@ -913,19 +815,8 @@ fn test_trace_amt_functions() -> i32 {
         issuer,
         currency,
     };
-    let trace_result = trace_amt("Test IOU amount", &iou_amount);
-    match trace_result {
-        host::Result::Ok(_) => {
-            trace("SUCCESS: trace_amt with IOU");
-        }
-        host::Result::Err(_) => {
-            trace_num(
-                "ERROR: trace_amt IOU failed:",
-                trace_result.err().unwrap().code() as i64,
-            );
-            return -610; // Trace amount IOU failed
-        }
-    }
+    trace_amt("Test IOU amount", &iou_amount);
+    trace("SUCCESS: trace_amt with IOU");
 
     // Test 6.5.7: trace_amt() with MPT amount (positive)
     const MPT_VALUE: u64 = 500_000;
@@ -939,19 +830,8 @@ fn test_trace_amt_functions() -> i32 {
         is_positive: true,
         mpt_id,
     };
-    let trace_result = trace_amt("Test positive MPT amount", &mpt_amount);
-    match trace_result {
-        host::Result::Ok(_) => {
-            trace("SUCCESS: trace_amt with positive MPT");
-        }
-        host::Result::Err(_) => {
-            trace_num(
-                "ERROR: trace_amt positive MPT failed:",
-                trace_result.err().unwrap().code() as i64,
-            );
-            return -611; // Trace amount positive MPT failed
-        }
-    }
+    trace_amt("Test positive MPT amount", &mpt_amount);
+    trace("SUCCESS: trace_amt with positive MPT");
 
     // Test 6.5.8: trace_amt() with MPT amount (negative)
     let negative_mpt_amount = Amount::MPT {
@@ -959,19 +839,8 @@ fn test_trace_amt_functions() -> i32 {
         is_positive: false,
         mpt_id,
     };
-    let trace_result = trace_amt("Test negative MPT amount", &negative_mpt_amount);
-    match trace_result {
-        host::Result::Ok(_) => {
-            trace("SUCCESS: trace_amt with negative MPT");
-        }
-        host::Result::Err(_) => {
-            trace_num(
-                "ERROR: trace_amt negative MPT failed:",
-                trace_result.err().unwrap().code() as i64,
-            );
-            return -612; // Trace amount negative MPT failed
-        }
-    }
+    trace_amt("Test negative MPT amount", &negative_mpt_amount);
+    trace("SUCCESS: trace_amt with negative MPT");
 
     // Test 6.5.9: trace_amt() with zero MPT amount
     // TODO: uncomment when new devnet is deployed

--- a/e2e-tests/host_functions_test/src/lib.rs
+++ b/e2e-tests/host_functions_test/src/lib.rs
@@ -40,8 +40,8 @@ use xrpl_escrow_stdlib::current_tx::escrow_finish::EscrowFinish;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn escrow_finish() -> i32 {
-    let _ = trace("=== HOST FUNCTIONS TEST ===");
-    let _ = trace("Testing 27 host functions");
+    trace("=== HOST FUNCTIONS TEST ===");
+    trace("Testing 27 host functions");
 
     // Category 1: Ledger Header Data Functions (3 functions)
     // Error range: -100 to -199
@@ -92,7 +92,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         err => return err,
     }
 
-    let _ = trace("SUCCESS: All host function tests passed!");
+    trace("SUCCESS: All host function tests passed!");
     1 // Success return code for WASM finish function
 }
 
@@ -101,18 +101,18 @@ pub extern "C" fn escrow_finish() -> i32 {
 /// - parent_ldgr_time() - Get parent ledger timestamp
 /// - parent_ldgr_hash() - Get parent ledger hash
 fn test_ledger_header_functions() -> i32 {
-    let _ = trace("--- Category 1: Ledger Header Functions ---");
+    trace("--- Category 1: Ledger Header Functions ---");
 
     // Test 1.1: ldgr_index() - should return current ledger sequence number
     let mut sqn_buffer = [0u8; 4];
     let sqn_result = unsafe { host::ldgr_index(sqn_buffer.as_mut_ptr(), sqn_buffer.len()) };
 
     if sqn_result <= 0 {
-        let _ = trace_num("ERROR: ldgr_index failed:", sqn_result as i64);
+        trace_num("ERROR: ldgr_index failed:", sqn_result as i64);
         return -101; // Ledger sequence number test failed
     }
     let ledger_sqn = u32::from_be_bytes(sqn_buffer);
-    let _ = trace_num("Ledger sequence number:", ledger_sqn as i64);
+    trace_num("Ledger sequence number:", ledger_sqn as i64);
 
     // Test 1.2: parent_ldgr_time() - should return parent ledger timestamp
     let mut time_buffer = [0u8; 4];
@@ -120,11 +120,11 @@ fn test_ledger_header_functions() -> i32 {
         unsafe { host::parent_ldgr_time(time_buffer.as_mut_ptr(), time_buffer.len()) };
 
     if time_result <= 0 {
-        let _ = trace_num("ERROR: parent_ldgr_time failed:", time_result as i64);
+        trace_num("ERROR: parent_ldgr_time failed:", time_result as i64);
         return -102; // Parent ledger time test failed
     }
     let parent_ledger_time = u32::from_be_bytes(time_buffer);
-    let _ = trace_num("Parent ledger time:", parent_ledger_time as i64);
+    trace_num("Parent ledger time:", parent_ledger_time as i64);
 
     // Test 1.3: parent_ldgr_hash() - should return parent ledger hash (32 bytes)
     let mut hash_buffer = [0u8; 32];
@@ -132,19 +132,19 @@ fn test_ledger_header_functions() -> i32 {
         unsafe { host::parent_ldgr_hash(hash_buffer.as_mut_ptr(), hash_buffer.len()) };
 
     if hash_result != 32 {
-        let _ = trace_num("ERROR: parent_ldgr_hash wrong length:", hash_result as i64);
+        trace_num("ERROR: parent_ldgr_hash wrong length:", hash_result as i64);
         return -103; // Parent ledger hash test failed - should be exactly 32 bytes
     }
-    let _ = trace_data("Parent ledger hash:", &hash_buffer, DataRepr::AsHex);
+    trace_data("Parent ledger hash:", &hash_buffer, DataRepr::AsHex);
 
-    let _ = trace("SUCCESS: Ledger header functions");
+    trace("SUCCESS: Ledger header functions");
     0
 }
 
 /// Test Category 2: Transaction Data Functions (5 functions)
 /// Tests all functions for accessing current transaction data
 fn test_transaction_data_functions() -> i32 {
-    let _ = trace("--- Category 2: Transaction Data Functions ---");
+    trace("--- Category 2: Transaction Data Functions ---");
 
     // Test 2.1: tx_field() - Basic transaction field access
     // Test with Account field (required, 20 bytes)
@@ -158,10 +158,10 @@ fn test_transaction_data_functions() -> i32 {
     };
 
     if account_len != 20 {
-        let _ = trace_num("ERROR: tx_field(Account) wrong length:", account_len as i64);
+        trace_num("ERROR: tx_field(Account) wrong length:", account_len as i64);
         return -201; // Basic transaction field test failed
     }
-    let _ = trace_acct_buf("Transaction Account:", &account_buffer);
+    trace_acct_buf("Transaction Account:", &account_buffer);
 
     // Test with Fee field (XRP amount - 8 bytes in new serialized format)
     // New format: XRP amounts are always 8 bytes (positive: value | cPositive flag, negative: just value)
@@ -175,14 +175,14 @@ fn test_transaction_data_functions() -> i32 {
     };
 
     if fee_len != 8 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: tx_field(Fee) wrong length (expected 8 bytes for XRP):",
             fee_len as i64,
         );
         return -202; // Fee field test failed - XRP amounts should be exactly 8 bytes
     }
-    let _ = trace_num("Transaction Fee length:", fee_len as i64);
-    let _ = trace_data(
+    trace_num("Transaction Fee length:", fee_len as i64);
+    trace_data(
         "Transaction Fee (serialized XRP amount):",
         &fee_buffer,
         DataRepr::AsHex,
@@ -199,10 +199,10 @@ fn test_transaction_data_functions() -> i32 {
     };
 
     if seq_len != 4 {
-        let _ = trace_num("ERROR: tx_field(Sequence) wrong length:", seq_len as i64);
+        trace_num("ERROR: tx_field(Sequence) wrong length:", seq_len as i64);
         return -203; // Sequence field test failed
     }
-    let _ = trace_data("Transaction Sequence:", &seq_buffer, DataRepr::AsHex);
+    trace_data("Transaction Sequence:", &seq_buffer, DataRepr::AsHex);
 
     // NOTE: tx_field2() through tx_field6() have been deprecated.
     // Use tx_field() with appropriate parameters for all transaction field access.
@@ -220,11 +220,11 @@ fn test_transaction_data_functions() -> i32 {
     };
 
     if inner_result < 0 {
-        let _ = trace_num("INFO: tx_inner not applicable:", inner_result as i64);
+        trace_num("INFO: tx_inner not applicable:", inner_result as i64);
         // Expected - locator may not match transaction structure
     } else {
-        let _ = trace_num("Inner field length:", inner_result as i64);
-        let _ = trace_data(
+        trace_num("Inner field length:", inner_result as i64);
+        trace_data(
             "Inner field:",
             &inner_buffer[..inner_result as usize],
             DataRepr::AsHex,
@@ -233,31 +233,31 @@ fn test_transaction_data_functions() -> i32 {
 
     // Test 2.3: tx_arr_len() - Get array length
     let signers_len = unsafe { host::tx_arr_len(sfield::Signers.into()) };
-    let _ = trace_num("Signers array length:", signers_len as i64);
+    trace_num("Signers array length:", signers_len as i64);
 
     let memos_len = unsafe { host::tx_arr_len(sfield::Memos.into()) };
-    let _ = trace_num("Memos array length:", memos_len as i64);
+    trace_num("Memos array length:", memos_len as i64);
 
     // Test 2.4: tx_inner_arr_len() - Get inner array length with locator
     let inner_array_len = unsafe { host::tx_inner_arr_len(locator.as_ptr(), locator.len()) };
 
     if inner_array_len < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: tx_inner_arr_len not applicable:",
             inner_array_len as i64,
         );
     } else {
-        let _ = trace_num("Inner array length:", inner_array_len as i64);
+        trace_num("Inner array length:", inner_array_len as i64);
     }
 
-    let _ = trace("SUCCESS: Transaction data functions");
+    trace("SUCCESS: Transaction data functions");
     0
 }
 
 /// Test Category 3: Current Ledger Object Functions (4 functions)
 /// Tests functions that access the current ledger object being processed
 fn test_current_ledger_object_functions() -> i32 {
-    let _ = trace("--- Category 3: Current Ledger Object Functions ---");
+    trace("--- Category 3: Current Ledger Object Functions ---");
 
     // Test 3.1: home_le_field() - Access field from current ledger object
     // Test with Balance field (XRP amount - 8 bytes in new serialized format)
@@ -271,27 +271,27 @@ fn test_current_ledger_object_functions() -> i32 {
     };
 
     if balance_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: home_le_field(Balance) failed (may be expected):",
             balance_result as i64,
         );
         // This might fail if current ledger object doesn't have balance field
     } else if balance_result == 8 {
-        let _ = trace_num(
+        trace_num(
             "Current object balance length (XRP amount):",
             balance_result as i64,
         );
-        let _ = trace_data(
+        trace_data(
             "Current object balance (serialized XRP amount):",
             &balance_buffer,
             DataRepr::AsHex,
         );
     } else {
-        let _ = trace_num(
+        trace_num(
             "Current object balance length (non-XRP amount):",
             balance_result as i64,
         );
-        let _ = trace_data(
+        trace_data(
             "Current object balance:",
             &balance_buffer[..balance_result as usize],
             DataRepr::AsHex,
@@ -309,12 +309,12 @@ fn test_current_ledger_object_functions() -> i32 {
     };
 
     if current_account_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: home_le_field(Account) failed:",
             current_account_result as i64,
         );
     } else {
-        let _ = trace_acct_buf("Current ledger object account:", &current_account_buffer);
+        trace_acct_buf("Current ledger object account:", &current_account_buffer);
     }
 
     // Test 3.2: home_le_inner() - Inner field access
@@ -330,13 +330,13 @@ fn test_current_ledger_object_functions() -> i32 {
     };
 
     if current_inner_result < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: home_le_inner not applicable:",
             current_inner_result as i64,
         );
     } else {
-        let _ = trace_num("Current inner field length:", current_inner_result as i64);
-        let _ = trace_data(
+        trace_num("Current inner field length:", current_inner_result as i64);
+        trace_data(
             "Current inner field:",
             &current_inner_buffer[..current_inner_result as usize],
             DataRepr::AsHex,
@@ -345,7 +345,7 @@ fn test_current_ledger_object_functions() -> i32 {
 
     // Test 3.3: home_le_arr_len() - Array length in current object
     let current_array_len = unsafe { host::home_le_arr_len(sfield::Signers.into()) };
-    let _ = trace_num(
+    trace_num(
         "Current object Signers array length:",
         current_array_len as i64,
     );
@@ -355,25 +355,25 @@ fn test_current_ledger_object_functions() -> i32 {
         unsafe { host::home_le_inner_arr_len(locator.as_ptr(), locator.len()) };
 
     if current_inner_array_len < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: home_le_inner_arr_len not applicable:",
             current_inner_array_len as i64,
         );
     } else {
-        let _ = trace_num(
+        trace_num(
             "Current inner array length:",
             current_inner_array_len as i64,
         );
     }
 
-    let _ = trace("SUCCESS: Current ledger object functions");
+    trace("SUCCESS: Current ledger object functions");
     0
 }
 
 /// Test Category 4: Any Ledger Object Functions (5 functions)
 /// Tests functions that work with cached ledger objects
 fn test_any_ledger_object_functions() -> i32 {
-    let _ = trace("--- Category 4: Any Ledger Object Functions ---");
+    trace("--- Category 4: Any Ledger Object Functions ---");
 
     // First we need to cache a ledger object to test the other functions
     // Get the account from transaction and generate its ledger entry ID
@@ -392,7 +392,7 @@ fn test_any_ledger_object_functions() -> i32 {
     };
 
     if id_result != 32 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: accountroot_id failed for caching test:",
             id_result as i64,
         );
@@ -402,7 +402,7 @@ fn test_any_ledger_object_functions() -> i32 {
     let cache_result = unsafe { host::cache_le(id_buffer.as_ptr(), id_result as usize, 0) };
 
     if cache_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: cache_le failed (expected with test fixtures):",
             cache_result as i64,
         );
@@ -422,7 +422,7 @@ fn test_any_ledger_object_functions() -> i32 {
             )
         };
         if field_result < 0 {
-            let _ = trace_num(
+            trace_num(
                 "INFO: le_field failed as expected (no cached object):",
                 field_result as i64,
             );
@@ -440,32 +440,32 @@ fn test_any_ledger_object_functions() -> i32 {
             )
         };
         if inner_result < 0 {
-            let _ = trace_num("INFO: le_inner failed as expected:", inner_result as i64);
+            trace_num("INFO: le_inner failed as expected:", inner_result as i64);
         }
 
         // Test le_arr_len with invalid slot
         let array_result = unsafe { host::le_arr_len(1, sfield::Signers.into()) };
         if array_result < 0 {
-            let _ = trace_num("INFO: le_arr_len failed as expected:", array_result as i64);
+            trace_num("INFO: le_arr_len failed as expected:", array_result as i64);
         }
 
         // Test le_inner_arr_len with invalid slot
         let inner_array_result =
             unsafe { host::le_inner_arr_len(1, locator.as_ptr(), locator.len()) };
         if inner_array_result < 0 {
-            let _ = trace_num(
+            trace_num(
                 "INFO: le_inner_arr_len failed as expected:",
                 inner_array_result as i64,
             );
         }
 
-        let _ = trace("SUCCESS: Any ledger object functions (interface tested)");
+        trace("SUCCESS: Any ledger object functions (interface tested)");
         return 0;
     }
 
     // If we successfully cached an object, test the access functions
     let slot = cache_result;
-    let _ = trace_num("Successfully cached object in slot:", slot as i64);
+    trace_num("Successfully cached object in slot:", slot as i64);
 
     // Test 4.2: le_field() - Access field from cached object
     let mut cached_balance_buffer = [0u8; 8];
@@ -479,26 +479,26 @@ fn test_any_ledger_object_functions() -> i32 {
     };
 
     if cached_balance_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: le_field(Balance) failed:",
             cached_balance_result as i64,
         );
     } else if cached_balance_result == 8 {
-        let _ = trace_num(
+        trace_num(
             "Cached object balance length (XRP amount):",
             cached_balance_result as i64,
         );
-        let _ = trace_data(
+        trace_data(
             "Cached object balance (serialized XRP amount):",
             &cached_balance_buffer,
             DataRepr::AsHex,
         );
     } else {
-        let _ = trace_num(
+        trace_num(
             "Cached object balance length (non-XRP amount):",
             cached_balance_result as i64,
         );
-        let _ = trace_data(
+        trace_data(
             "Cached object balance:",
             &cached_balance_buffer[..cached_balance_result as usize],
             DataRepr::AsHex,
@@ -519,10 +519,10 @@ fn test_any_ledger_object_functions() -> i32 {
     };
 
     if cached_inner_result < 0 {
-        let _ = trace_num("INFO: le_inner not applicable:", cached_inner_result as i64);
+        trace_num("INFO: le_inner not applicable:", cached_inner_result as i64);
     } else {
-        let _ = trace_num("Cached inner field length:", cached_inner_result as i64);
-        let _ = trace_data(
+        trace_num("Cached inner field length:", cached_inner_result as i64);
+        trace_data(
             "Cached inner field:",
             &cached_inner_buffer[..cached_inner_result as usize],
             DataRepr::AsHex,
@@ -531,7 +531,7 @@ fn test_any_ledger_object_functions() -> i32 {
 
     // Test 4.4: le_arr_len() - Array length from cached object
     let cached_array_len = unsafe { host::le_arr_len(slot, sfield::Signers.into()) };
-    let _ = trace_num(
+    trace_num(
         "Cached object Signers array length:",
         cached_array_len as i64,
     );
@@ -541,22 +541,22 @@ fn test_any_ledger_object_functions() -> i32 {
         unsafe { host::le_inner_arr_len(slot, locator.as_ptr(), locator.len()) };
 
     if cached_inner_array_len < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: le_inner_arr_len not applicable:",
             cached_inner_array_len as i64,
         );
     } else {
-        let _ = trace_num("Cached inner array length:", cached_inner_array_len as i64);
+        trace_num("Cached inner array length:", cached_inner_array_len as i64);
     }
 
-    let _ = trace("SUCCESS: Any ledger object functions");
+    trace("SUCCESS: Any ledger object functions");
     0
 }
 
 /// Test Category 5: Ledger entry ID Generation Functions (4 functions)
 /// Tests ledger entry ID generation functions for different ledger entry types
 fn test_id_generation_functions() -> i32 {
-    let _ = trace("--- Category 5: LedgerEntryId Generation Functions ---");
+    trace("--- Category 5: LedgerEntryId Generation Functions ---");
 
     let escrow_finish = EscrowFinish;
     let account_id = escrow_finish.get_account().unwrap();
@@ -573,13 +573,13 @@ fn test_id_generation_functions() -> i32 {
     };
 
     if accountroot_id_result != 32 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: accountroot_id failed:",
             accountroot_id_result as i64,
         );
         return -501; // AccountRoot ledger entry ID generation failed
     }
-    let _ = trace_data(
+    trace_data(
         "AccountRoot ledger entry ID:",
         &accountroot_id_buffer,
         DataRepr::AsHex,
@@ -601,13 +601,13 @@ fn test_id_generation_functions() -> i32 {
     };
 
     if credential_id_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: credential_id failed (expected - interface issue):",
             credential_id_result as i64,
         );
         // This is expected to fail due to unusual parameter types
     } else {
-        let _ = trace_data(
+        trace_data(
             "Credential ledger entry ID:",
             &credential_id_buffer[..credential_id_result as usize],
             DataRepr::AsHex,
@@ -630,10 +630,10 @@ fn test_id_generation_functions() -> i32 {
     };
 
     if escrow_id_result != 32 {
-        let _ = trace_num("ERROR: escrow_id failed:", escrow_id_result as i64);
+        trace_num("ERROR: escrow_id failed:", escrow_id_result as i64);
         return -503; // Escrow ledger entry ID generation failed
     }
-    let _ = trace_data(
+    trace_data(
         "Escrow ledger entry ID:",
         &escrow_id_buffer,
         DataRepr::AsHex,
@@ -655,23 +655,23 @@ fn test_id_generation_functions() -> i32 {
     };
 
     if oracle_id_result != 32 {
-        let _ = trace_num("ERROR: oracle_id failed:", oracle_id_result as i64);
+        trace_num("ERROR: oracle_id failed:", oracle_id_result as i64);
         return -504; // Oracle ledger entry ID generation failed
     }
-    let _ = trace_data(
+    trace_data(
         "Oracle ledger entry ID:",
         &oracle_id_buffer,
         DataRepr::AsHex,
     );
 
-    let _ = trace("SUCCESS: LedgerEntryId generation functions");
+    trace("SUCCESS: LedgerEntryId generation functions");
     0
 }
 
 /// Test Category 6: Utility Functions (5 functions)
 /// Tests utility functions for hashing, NFT access, and tracing
 fn test_utility_functions() -> i32 {
-    let _ = trace("--- Category 6: Utility Functions ---");
+    trace("--- Category 6: Utility Functions ---");
 
     // Test 6.1: sha512_half() - SHA512 hash computation (first 32 bytes)
     let test_data = b"Hello, XRPL WASM world!";
@@ -686,11 +686,11 @@ fn test_utility_functions() -> i32 {
     };
 
     if hash_result != 32 {
-        let _ = trace_num("ERROR: sha512_half failed:", hash_result as i64);
+        trace_num("ERROR: sha512_half failed:", hash_result as i64);
         return -601; // SHA512 half computation failed
     }
-    let _ = trace_data("Input data:", test_data, DataRepr::AsHex);
-    let _ = trace_data("SHA512 half hash:", &hash_output, DataRepr::AsHex);
+    trace_data("Input data:", test_data, DataRepr::AsHex);
+    trace_data("SHA512 half hash:", &hash_output, DataRepr::AsHex);
 
     // Test 6.2: nft_uri() - NFT data retrieval
     let escrow_finish = EscrowFinish;
@@ -709,14 +709,14 @@ fn test_utility_functions() -> i32 {
     };
 
     if nft_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: nft_uri failed (expected - no such NFT):",
             nft_result as i64,
         );
         // This is expected - test account likely doesn't own the dummy NFT
     } else {
-        let _ = trace_num("NFT data length:", nft_result as i64);
-        let _ = trace_data(
+        trace_num("NFT data length:", nft_result as i64);
+        trace_data(
             "NFT data:",
             &nft_buffer[..nft_result as usize],
             DataRepr::AsHex,
@@ -737,10 +737,10 @@ fn test_utility_functions() -> i32 {
     };
 
     if trace_result < 0 {
-        let _ = trace_num("ERROR: trace() failed:", trace_result as i64);
+        trace_num("ERROR: trace() failed:", trace_result as i64);
         return -603; // Trace function failed
     }
-    let _ = trace_num("Trace function bytes written:", trace_result as i64);
+    trace_num("Trace function bytes written:", trace_result as i64);
 
     // Test 6.4: trace_num() - Debug logging with number
     let test_number = 42i64;
@@ -749,10 +749,10 @@ fn test_utility_functions() -> i32 {
     use xrpl_common_stdlib::host::Result;
     match trace_num_result {
         Result::Ok(_) => {
-            let _ = trace_num("Trace_num function succeeded", 0);
+            trace_num("Trace_num function succeeded", 0);
         }
         Result::Err(_) => {
-            let _ = trace_num(
+            trace_num(
                 "ERROR: trace_num() failed:",
                 trace_num_result.err().unwrap().code() as i64,
             );
@@ -766,14 +766,14 @@ fn test_utility_functions() -> i32 {
         err => return err,
     }
 
-    let _ = trace("SUCCESS: Utility functions");
+    trace("SUCCESS: Utility functions");
     0
 }
 
 /// Test Category 7: Data Update Functions (1 function)
 /// Tests the function for modifying the current ledger entry
 fn test_data_update_functions() -> i32 {
-    let _ = trace("--- Category 7: Data Update Functions ---");
+    trace("--- Category 7: Data Update Functions ---");
 
     // Test 7.1: set_data() - Update current ledger entry data
     let update_payload = b"Updated ledger entry data from WASM test";
@@ -781,23 +781,23 @@ fn test_data_update_functions() -> i32 {
     let update_result = unsafe { host::set_data(update_payload.as_ptr(), update_payload.len()) };
 
     if update_result != 0 {
-        let _ = trace_num("ERROR: set_data failed:", update_result as i64);
+        trace_num("ERROR: set_data failed:", update_result as i64);
         return -701; // Data update failed
     }
 
-    let _ = trace_data(
+    trace_data(
         "Successfully updated ledger entry with:",
         update_payload,
         DataRepr::AsHex,
     );
-    let _ = trace("SUCCESS: Data update functions");
+    trace("SUCCESS: Data update functions");
     1 // <-- Finish the escrow to indicate a successful outcome
 }
 
 /// Test trace_amt() function with different Amount types
 /// Tests the trace_amt host function with XRP, IOU, and MPT amounts
 fn test_trace_amt_functions() -> i32 {
-    let _ = trace("--- Testing trace_amt() function ---");
+    trace("--- Testing trace_amt() function ---");
 
     // Test 6.5.1: trace_amt() with XRP amount (positive)
     let xrp_amount = Amount::XRP {
@@ -806,10 +806,10 @@ fn test_trace_amt_functions() -> i32 {
     let trace_result = trace_amt("Test XRP amount (1 XRP)", &xrp_amount);
     match trace_result {
         host::Result::Ok(_) => {
-            let _ = trace("SUCCESS: trace_amt with positive XRP");
+            trace("SUCCESS: trace_amt with positive XRP");
         }
         host::Result::Err(_) => {
-            let _ = trace_num(
+            trace_num(
                 "ERROR: trace_amt XRP failed:",
                 trace_result.err().unwrap().code() as i64,
             );
@@ -824,10 +824,10 @@ fn test_trace_amt_functions() -> i32 {
     let trace_result = trace_amt("Test negative XRP amount (-0.5 XRP)", &negative_xrp_amount);
     match trace_result {
         host::Result::Ok(_) => {
-            let _ = trace("SUCCESS: trace_amt with negative XRP");
+            trace("SUCCESS: trace_amt with negative XRP");
         }
         host::Result::Err(_) => {
-            let _ = trace_num(
+            trace_num(
                 "ERROR: trace_amt negative XRP failed:",
                 trace_result.err().unwrap().code() as i64,
             );
@@ -841,10 +841,10 @@ fn test_trace_amt_functions() -> i32 {
     // let trace_result = trace_amt("Test zero XRP amount", &zero_xrp_amount);
     // match trace_result {
     //     host::Result::Ok(_) => {
-    //         let _ = trace("SUCCESS: trace_amt with zero XRP");
+    //         trace("SUCCESS: trace_amt with zero XRP");
     //     }
     //     host::Result::Err(_) => {
-    //         let _ = trace_num(
+    //         trace_num(
     //             "ERROR: trace_amt zero XRP failed:",
     //             trace_result.err().unwrap().code() as i64,
     //         );
@@ -857,10 +857,10 @@ fn test_trace_amt_functions() -> i32 {
     let trace_result = trace_amt("Test small XRP amount (10 drops)", &fee_amount);
     match trace_result {
         host::Result::Ok(_) => {
-            let _ = trace("SUCCESS: trace_amt with small XRP");
+            trace("SUCCESS: trace_amt with small XRP");
         }
         host::Result::Err(_) => {
-            let _ = trace_num(
+            trace_num(
                 "ERROR: trace_amt small XRP failed:",
                 trace_result.err().unwrap().code() as i64,
             );
@@ -875,10 +875,10 @@ fn test_trace_amt_functions() -> i32 {
     let trace_result = trace_amt("Test large XRP amount (100,000 XRP)", &large_xrp_amount);
     match trace_result {
         host::Result::Ok(_) => {
-            let _ = trace("SUCCESS: trace_amt with large XRP");
+            trace("SUCCESS: trace_amt with large XRP");
         }
         host::Result::Err(_) => {
-            let _ = trace_num(
+            trace_num(
                 "ERROR: trace_amt large XRP failed:",
                 trace_result.err().unwrap().code() as i64,
             );
@@ -886,7 +886,7 @@ fn test_trace_amt_functions() -> i32 {
         }
     }
 
-    let _ = trace("SUCCESS: trace_amt XRP tests completed");
+    trace("SUCCESS: trace_amt XRP tests completed");
 
     // Test 6.5.6: trace_amt() with IOU amount
     // USD currency code: 20 bytes with "USD" at positions 12-14, rest zeros
@@ -916,10 +916,10 @@ fn test_trace_amt_functions() -> i32 {
     let trace_result = trace_amt("Test IOU amount", &iou_amount);
     match trace_result {
         host::Result::Ok(_) => {
-            let _ = trace("SUCCESS: trace_amt with IOU");
+            trace("SUCCESS: trace_amt with IOU");
         }
         host::Result::Err(_) => {
-            let _ = trace_num(
+            trace_num(
                 "ERROR: trace_amt IOU failed:",
                 trace_result.err().unwrap().code() as i64,
             );
@@ -942,10 +942,10 @@ fn test_trace_amt_functions() -> i32 {
     let trace_result = trace_amt("Test positive MPT amount", &mpt_amount);
     match trace_result {
         host::Result::Ok(_) => {
-            let _ = trace("SUCCESS: trace_amt with positive MPT");
+            trace("SUCCESS: trace_amt with positive MPT");
         }
         host::Result::Err(_) => {
-            let _ = trace_num(
+            trace_num(
                 "ERROR: trace_amt positive MPT failed:",
                 trace_result.err().unwrap().code() as i64,
             );
@@ -962,10 +962,10 @@ fn test_trace_amt_functions() -> i32 {
     let trace_result = trace_amt("Test negative MPT amount", &negative_mpt_amount);
     match trace_result {
         host::Result::Ok(_) => {
-            let _ = trace("SUCCESS: trace_amt with negative MPT");
+            trace("SUCCESS: trace_amt with negative MPT");
         }
         host::Result::Err(_) => {
-            let _ = trace_num(
+            trace_num(
                 "ERROR: trace_amt negative MPT failed:",
                 trace_result.err().unwrap().code() as i64,
             );
@@ -983,10 +983,10 @@ fn test_trace_amt_functions() -> i32 {
     // let trace_result = trace_amt("Test zero MPT amount", &zero_mpt_amount);
     // match trace_result {
     //     host::Result::Ok(_) => {
-    //         let _ = trace("SUCCESS: trace_amt with zero MPT");
+    //         trace("SUCCESS: trace_amt with zero MPT");
     //     }
     //     host::Result::Err(_) => {
-    //         let _ = trace_num(
+    //         trace_num(
     //             "ERROR: trace_amt zero MPT failed:",
     //             trace_result.err().unwrap().code() as i64,
     //         );
@@ -994,7 +994,7 @@ fn test_trace_amt_functions() -> i32 {
     //     }
     // }
 
-    let _ = trace("SUCCESS: All trace_amt tests completed");
+    trace("SUCCESS: All trace_amt tests completed");
     1
 }
 

--- a/e2e-tests/keylet_exists/src/lib.rs
+++ b/e2e-tests/keylet_exists/src/lib.rs
@@ -24,34 +24,34 @@ pub fn object_exists<T, const CODE: i32>(
 ) -> Result<bool> {
     match id_result {
         Ok(id) => {
-            let _ = trace_data(id_type, &id, DataRepr::AsHex);
+            trace_data(id_type, &id, DataRepr::AsHex);
 
             let slot = unsafe { host::cache_le(id.as_ptr(), id.len(), 0) };
             if slot < 0 {
-                let _ = trace_num("Error: ", slot.into());
+                trace_num("Error: ", slot.into());
                 return Err(Error::from_code(slot));
             }
             if CODE == 0 {
                 let field_code: i32 = sfield::PreviousTxnID.into();
-                let _ = trace_num("Getting field: ", field_code as i64);
+                trace_num("Getting field: ", field_code as i64);
                 match ledger_object::get_field(slot, sfield::PreviousTxnID) {
                     Ok(data) => {
-                        let _ = trace_data("Field data: ", &data.0, DataRepr::AsHex);
+                        trace_data("Field data: ", &data.0, DataRepr::AsHex);
                     }
                     Err(result_code) => {
-                        let _ = trace_num("Error getting field: ", result_code.into());
+                        trace_num("Error getting field: ", result_code.into());
                         return Err(result_code);
                     }
                 }
             } else {
                 let field_code: i32 = field.into();
-                let _ = trace_num("Getting field: ", field_code as i64);
+                trace_num("Getting field: ", field_code as i64);
                 match ledger_object::get_field(slot, sfield::Account) {
                     Ok(data) => {
-                        let _ = trace_data("Field data: ", &data.0, DataRepr::AsHex);
+                        trace_data("Field data: ", &data.0, DataRepr::AsHex);
                     }
                     Err(result_code) => {
-                        let _ = trace_num("Error getting field: ", result_code.into());
+                        trace_num("Error getting field: ", result_code.into());
                         return Err(result_code);
                     }
                 }
@@ -60,7 +60,7 @@ pub fn object_exists<T, const CODE: i32>(
             Ok(true)
         }
         Err(error) => {
-            let _ = trace_num("Error getting ledger entry ID: ", error.into());
+            trace_num("Error getting ledger entry ID: ", error.into());
             Err(error)
         }
     }
@@ -68,15 +68,15 @@ pub fn object_exists<T, const CODE: i32>(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn escrow_finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
 
     let escrow: CurrentEscrow = get_current_escrow();
 
     let account = escrow.get_account().unwrap_or_panic();
-    let _ = trace_acct("Account:", &account);
+    trace_acct("Account:", &account);
 
     let destination = escrow.get_destination().unwrap_or_panic();
-    let _ = trace_acct("Destination:", &destination);
+    trace_acct("Destination:", &destination);
 
     let mut seq = 5;
 
@@ -85,13 +85,13 @@ pub extern "C" fn escrow_finish() -> i32 {
             match object_exists($id, $type, $field) {
                 Ok(_exists) => {
                     // false isn't returned
-                    let _ = trace(concat!(
+                    trace(concat!(
                         $type,
                         " object exists, proceeding with escrow finish."
                     ));
                 }
                 Err(error) => {
-                    let _ = trace_num("Current seq value:", seq.try_into().unwrap());
+                    trace_num("Current seq value:", seq.try_into().unwrap());
                     return error.code();
                 }
             }

--- a/e2e-tests/keylet_exists/src/lib.rs
+++ b/e2e-tests/keylet_exists/src/lib.rs
@@ -5,7 +5,7 @@ extern crate std;
 
 use crate::host::{Error, Result, Result::Err, Result::Ok};
 use xrpl_common_stdlib::host;
-use xrpl_common_stdlib::host::trace::{DataRepr, trace, trace_acct, trace_data, trace_num};
+use xrpl_common_stdlib::host::trace::{trace, trace_acct, trace_hex, trace_num};
 use xrpl_common_stdlib::ledger_entry_ids;
 use xrpl_common_stdlib::objects::ledger_object;
 use xrpl_common_stdlib::sfield;
@@ -24,7 +24,7 @@ pub fn object_exists<T, const CODE: i32>(
 ) -> Result<bool> {
     match id_result {
         Ok(id) => {
-            trace_data(id_type, &id, DataRepr::AsHex);
+            trace_hex(id_type, &id);
 
             let slot = unsafe { host::cache_le(id.as_ptr(), id.len(), 0) };
             if slot < 0 {
@@ -36,7 +36,7 @@ pub fn object_exists<T, const CODE: i32>(
                 trace_num("Getting field: ", field_code as i64);
                 match ledger_object::get_field(slot, sfield::PreviousTxnID) {
                     Ok(data) => {
-                        trace_data("Field data: ", &data.0, DataRepr::AsHex);
+                        trace_hex("Field data: ", &data.0);
                     }
                     Err(result_code) => {
                         trace_num("Error getting field: ", result_code.into());
@@ -48,7 +48,7 @@ pub fn object_exists<T, const CODE: i32>(
                 trace_num("Getting field: ", field_code as i64);
                 match ledger_object::get_field(slot, sfield::Account) {
                     Ok(data) => {
-                        trace_data("Field data: ", &data.0, DataRepr::AsHex);
+                        trace_hex("Field data: ", &data.0);
                     }
                     Err(result_code) => {
                         trace_num("Error getting field: ", result_code.into());

--- a/e2e-tests/test_utils/src/assert.rs
+++ b/e2e-tests/test_utils/src/assert.rs
@@ -26,7 +26,7 @@ macro_rules! impl_trace_numeric {
             impl TraceValue for $t {
                 #[inline]
                 fn trace_value(msg: &str, value: &$t) {
-                    let _ = trace_num(msg, *value as i64);
+                    trace_num(msg, *value as i64);
                 }
             }
         )*
@@ -44,11 +44,11 @@ impl TraceValue for u64 {
     #[inline]
     fn trace_value(msg: &str, value: &u64) {
         if *value <= i64::MAX as u64 {
-            let _ = trace_num(msg, *value as i64);
+            trace_num(msg, *value as i64);
         } else {
             // Value too large for i64, use hex representation
             let bytes = value.to_be_bytes();
-            let _ = trace_data(msg, &bytes, DataRepr::AsHex);
+            trace_data(msg, &bytes, DataRepr::AsHex);
         }
     }
 }
@@ -57,11 +57,11 @@ impl TraceValue for usize {
     #[inline]
     fn trace_value(msg: &str, value: &usize) {
         if *value <= i64::MAX as usize {
-            let _ = trace_num(msg, *value as i64);
+            trace_num(msg, *value as i64);
         } else {
             // Value too large for i64, use hex representation
             let bytes = value.to_be_bytes();
-            let _ = trace_data(msg, &bytes, DataRepr::AsHex);
+            trace_data(msg, &bytes, DataRepr::AsHex);
         }
     }
 }
@@ -70,7 +70,7 @@ impl TraceValue for usize {
 impl<const N: usize> TraceValue for [u8; N] {
     #[inline]
     fn trace_value(msg: &str, value: &[u8; N]) {
-        let _ = trace_data(msg, value, DataRepr::AsHex);
+        trace_data(msg, value, DataRepr::AsHex);
     }
 }
 
@@ -78,7 +78,7 @@ impl<const N: usize> TraceValue for [u8; N] {
 impl TraceValue for &[u8] {
     #[inline]
     fn trace_value(msg: &str, value: &&[u8]) {
-        let _ = trace_data(msg, value, DataRepr::AsHex);
+        trace_data(msg, value, DataRepr::AsHex);
     }
 }
 
@@ -87,7 +87,7 @@ impl TraceValue for &[u8] {
 impl<const N: usize> TraceValue for &[u8; N] {
     #[inline]
     fn trace_value(msg: &str, value: &&[u8; N]) {
-        let _ = trace_data(msg, *value, DataRepr::AsHex);
+        trace_data(msg, *value, DataRepr::AsHex);
     }
 }
 
@@ -95,7 +95,7 @@ impl<const N: usize> TraceValue for &[u8; N] {
 impl TraceValue for TransactionType {
     #[inline]
     fn trace_value(msg: &str, value: &TransactionType) {
-        let _ = trace_num(msg, *value as i64);
+        trace_num(msg, *value as i64);
     }
 }
 
@@ -105,7 +105,7 @@ pub fn trace_value_generic<T>(msg: &str, value: &T) {
     let data_ptr = value as *const T as *const u8;
     let data_len = core::mem::size_of::<T>();
     let data_slice = unsafe { core::slice::from_raw_parts(data_ptr, data_len) };
-    let _ = trace_data(msg, data_slice, DataRepr::AsHex);
+    trace_data(msg, data_slice, DataRepr::AsHex);
 }
 
 /// Asserts that two expressions are equal.
@@ -133,7 +133,7 @@ macro_rules! assert_eq {
             #[cfg(target_arch = "wasm32")]
             {
                 if left_val != right_val {
-                    let _ = xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " != ", stringify!($right)));
+                    xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " != ", stringify!($right)));
                     <_ as $crate::assert::TraceValue>::trace_value("  left: ", &left_val);
                     <_ as $crate::assert::TraceValue>::trace_value("  right: ", &right_val);
                     panic!("assertion failed: {} != {}", stringify!($left), stringify!($right));
@@ -148,10 +148,10 @@ macro_rules! assert_eq {
             #[cfg(target_arch = "wasm32")]
             {
                 if left_val != right_val {
-                    let _ = xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " != ", stringify!($right)));
+                    xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " != ", stringify!($right)));
                     <_ as $crate::assert::TraceValue>::trace_value("  left: ", &left_val);
                     <_ as $crate::assert::TraceValue>::trace_value("  right: ", &right_val);
-                    let _ = xrpl_common_stdlib::host::trace::trace("  message: (see panic message for details)");
+                    xrpl_common_stdlib::host::trace::trace("  message: (see panic message for details)");
                     panic!("assertion failed: {} != {}: {}", stringify!($left), stringify!($right), format_args!($($arg)+));
                 }
             }
@@ -183,7 +183,7 @@ macro_rules! assert {
             #[cfg(target_arch = "wasm32")]
             {
                 if !cond_val {
-                    let _ = xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($cond)));
+                    xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($cond)));
                     panic!("assertion failed: {}", stringify!($cond));
                 }
             }
@@ -195,8 +195,8 @@ macro_rules! assert {
             #[cfg(target_arch = "wasm32")]
             {
                 if !cond_val {
-                    let _ = xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($cond)));
-                    let _ = xrpl_common_stdlib::host::trace::trace("  message: (see panic message for details)");
+                    xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($cond)));
+                    xrpl_common_stdlib::host::trace::trace("  message: (see panic message for details)");
                     panic!("assertion failed: {}: {}", stringify!($cond), format_args!($($arg)+));
                 }
             }
@@ -229,7 +229,7 @@ macro_rules! assert_ne {
             #[cfg(target_arch = "wasm32")]
             {
                 if left_val == right_val {
-                    let _ = xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " == ", stringify!($right)));
+                    xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " == ", stringify!($right)));
                     <_ as $crate::assert::TraceValue>::trace_value("  value: ", &left_val);
                     panic!("assertion failed: {} == {}", stringify!($left), stringify!($right));
                 }
@@ -243,9 +243,9 @@ macro_rules! assert_ne {
             #[cfg(target_arch = "wasm32")]
             {
                 if left_val == right_val {
-                    let _ = xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " == ", stringify!($right)));
+                    xrpl_common_stdlib::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " == ", stringify!($right)));
                     <_ as $crate::assert::TraceValue>::trace_value("  value: ", &left_val);
-                    let _ = xrpl_common_stdlib::host::trace::trace("  message: (see panic message for details)");
+                    xrpl_common_stdlib::host::trace::trace("  message: (see panic message for details)");
                     panic!("assertion failed: {} == {}: {}", stringify!($left), stringify!($right), format_args!($($arg)+));
                 }
             }

--- a/e2e-tests/test_utils/src/assert.rs
+++ b/e2e-tests/test_utils/src/assert.rs
@@ -7,7 +7,7 @@
 //! targets, the expressions are evaluated (preserving side effects) but the
 //! assertions themselves are skipped.
 
-use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+use xrpl_common_stdlib::host::trace::{trace_hex, trace_num};
 use xrpl_common_stdlib::types::transaction_type::TransactionType;
 
 /// Trait for types that can be traced in assertions.
@@ -48,7 +48,7 @@ impl TraceValue for u64 {
         } else {
             // Value too large for i64, use hex representation
             let bytes = value.to_be_bytes();
-            trace_data(msg, &bytes, DataRepr::AsHex);
+            trace_hex(msg, &bytes);
         }
     }
 }
@@ -61,7 +61,7 @@ impl TraceValue for usize {
         } else {
             // Value too large for i64, use hex representation
             let bytes = value.to_be_bytes();
-            trace_data(msg, &bytes, DataRepr::AsHex);
+            trace_hex(msg, &bytes);
         }
     }
 }
@@ -70,7 +70,7 @@ impl TraceValue for usize {
 impl<const N: usize> TraceValue for [u8; N] {
     #[inline]
     fn trace_value(msg: &str, value: &[u8; N]) {
-        trace_data(msg, value, DataRepr::AsHex);
+        trace_hex(msg, value);
     }
 }
 
@@ -78,7 +78,7 @@ impl<const N: usize> TraceValue for [u8; N] {
 impl TraceValue for &[u8] {
     #[inline]
     fn trace_value(msg: &str, value: &&[u8]) {
-        trace_data(msg, value, DataRepr::AsHex);
+        trace_hex(msg, value);
     }
 }
 
@@ -87,7 +87,7 @@ impl TraceValue for &[u8] {
 impl<const N: usize> TraceValue for &[u8; N] {
     #[inline]
     fn trace_value(msg: &str, value: &&[u8; N]) {
-        trace_data(msg, *value, DataRepr::AsHex);
+        trace_hex(msg, *value);
     }
 }
 
@@ -105,7 +105,7 @@ pub fn trace_value_generic<T>(msg: &str, value: &T) {
     let data_ptr = value as *const T as *const u8;
     let data_len = core::mem::size_of::<T>();
     let data_slice = unsafe { core::slice::from_raw_parts(data_ptr, data_len) };
-    trace_data(msg, data_slice, DataRepr::AsHex);
+    trace_hex(msg, data_slice);
 }
 
 /// Asserts that two expressions are equal.

--- a/e2e-tests/trace_escrow_account/src/lib.rs
+++ b/e2e-tests/trace_escrow_account/src/lib.rs
@@ -11,7 +11,7 @@
 
 use xrpl_common_stdlib::current_tx::traits::TransactionCommonFields;
 use xrpl_common_stdlib::host::cache_le;
-use xrpl_common_stdlib::host::trace::{DataRepr, trace, trace_amt, trace_data, trace_num};
+use xrpl_common_stdlib::host::trace::{trace, trace_amt, trace_hex, trace_num};
 use xrpl_common_stdlib::ledger_entry_ids::accountroot_id;
 use xrpl_common_stdlib::objects::AccountRoot;
 use xrpl_common_stdlib::objects::traits::{AccountRootFields, LedgerObjectCommonFields};
@@ -83,7 +83,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         let account_id = account.account().unwrap();
         // Account is the hardcoded ledger entry ID we're looking up - just verify it's 20 bytes
         test_utils::assert_eq!(account_id.0.len(), 20);
-        trace_data("  Account:", &account_id.0, DataRepr::AsHex);
+        trace_hex("  Account:", &account_id.0);
 
         // Trace the `AccountTxnID` (optional - required for testing)
         let account_txn_id_opt = account.account_txn_id().unwrap();
@@ -91,7 +91,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             account_txn_id_opt.expect("AccountTxnID should be present for testing");
         // AccountTxnID is system-generated - just verify it's 32 bytes
         test_utils::assert_eq!(account_txn_id.0.len(), 32);
-        trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
+        trace_hex("  AccountTxnID:", &account_txn_id.0);
 
         // Trace `AMMID` (optional - only present on AMM AccountRoot entries)
         // Note: This is a regular account, not an AMM account, so AMMID should be None
@@ -137,7 +137,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             &expected_domain[..],
             "Domain should be 'example.com'"
         );
-        trace_data("  Domain:", &domain.data[..domain.len], DataRepr::AsHex);
+        trace_hex("  Domain:", &domain.data[..domain.len]);
 
         // Trace the `EmailHash` (optional - required for testing)
         let email_hash_opt = account.email_hash().unwrap();
@@ -153,7 +153,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             expected_email_hash,
             "EmailHash should be MD5 of 'hello'"
         );
-        trace_data("  EmailHash:", &email_hash.0, DataRepr::AsHex);
+        trace_hex("  EmailHash:", &email_hash.0);
 
         // Trace the `FirstNFTokenSequence` (optional - required for testing)
         let first_nf_token_sequence = account
@@ -177,11 +177,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             &expected_message_key,
             "MessageKey mismatch"
         );
-        trace_data(
-            "  MessageKey:",
-            &message_key.data[..message_key.len],
-            DataRepr::AsHex,
-        );
+        trace_hex("  MessageKey:", &message_key.data[..message_key.len]);
 
         // Trace the `MintedNFTokens` (optional - required for testing)
         let minted_nf_tokens = account
@@ -199,7 +195,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             .expect("NFTokenMinter should be set for testing");
         // NFTokenMinter is an AccountID - verify it's 20 bytes
         test_utils::assert_eq!(nf_token_minter.0.len(), 20);
-        trace_data("  NFTokenMinter:", &nf_token_minter.0, DataRepr::AsHex);
+        trace_hex("  NFTokenMinter:", &nf_token_minter.0);
 
         // Trace the `OwnerCount` (required)
         let owner_count = account.owner_count().unwrap();
@@ -210,7 +206,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         let previous_txn_id = account.previous_txn_id().unwrap();
         // PreviousTxnID is system-generated - just verify it's 32 bytes
         test_utils::assert_eq!(previous_txn_id.0.len(), 32);
-        trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
+        trace_hex("  PreviousTxnID:", &previous_txn_id.0);
 
         // Trace the `PreviousTxnLgrSeq` (required)
         let previous_txn_lgr_seq = account.previous_txn_lgr_seq().unwrap();
@@ -224,7 +220,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             .expect("RegularKey should be set for testing");
         // RegularKey is an AccountID - verify it's 20 bytes
         test_utils::assert_eq!(regular_key.0.len(), 20);
-        trace_data("  RegularKey:", &regular_key.0, DataRepr::AsHex);
+        trace_hex("  RegularKey:", &regular_key.0);
 
         // Trace the `Sequence` (required)
         let sequence = account.sequence().unwrap();
@@ -275,7 +271,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             expected_wallet_locator,
             "WalletLocator should be all 0xAA bytes"
         );
-        trace_data("  WalletLocator:", &wallet_locator.0, DataRepr::AsHex);
+        trace_hex("  WalletLocator:", &wallet_locator.0);
 
         trace("}");
         trace("");

--- a/e2e-tests/trace_escrow_account/src/lib.rs
+++ b/e2e-tests/trace_escrow_account/src/lib.rs
@@ -25,8 +25,8 @@ use xrpl_common_stdlib::types::amount::Amount;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn escrow_finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
-    let _ = trace("");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("");
 
     // The transaction prompting execution of this contract.
     let escrow_finish: EscrowFinish = get_current_escrow_finish();
@@ -46,18 +46,18 @@ pub extern "C" fn escrow_finish() -> i32 {
         // Try to cache the ledger object inside rippled
         let slot = unsafe { cache_le(accountroot_id.as_ptr(), 32, 0) };
         if slot < 0 {
-            let _ = trace_num("Error slotting Account object", slot as i64);
+            trace_num("Error slotting Account object", slot as i64);
             panic!()
         } else {
-            let _ = trace_num("Account object slotted at", slot as i64);
+            trace_num("Account object slotted at", slot as i64);
         }
 
         // We use the trait-bound implementation so as not to duplicate accessor logic.
         let account = AccountRoot::new(slot);
 
-        let _ = trace("### Step #2: Trace AccountRoot Ledger Object");
-        let _ = trace("{ ");
-        let _ = trace("  -- Common Fields");
+        trace("### Step #2: Trace AccountRoot Ledger Object");
+        trace("{ ");
+        trace("  -- Common Fields");
 
         // Trace the `Flags`
         let flags = account.get_flags().unwrap();
@@ -68,22 +68,22 @@ pub extern "C" fn escrow_finish() -> i32 {
             65536,
             "Expected flags to be 0x00010000 (lsfPasswordSpent)"
         );
-        let _ = trace_num("  Flags:", flags as i64);
+        trace_num("  Flags:", flags as i64);
 
         // Trace the `LedgerEntryType`
         let ledger_entry_type = account.get_ledger_entry_type().unwrap();
         test_utils::assert_eq!(ledger_entry_type, 97); // 97 is the code for "AccountRoot"
-        let _ = trace_num("  LedgerEntryType (AccountRoot):", ledger_entry_type as i64);
-        let _ = trace("} ");
+        trace_num("  LedgerEntryType (AccountRoot):", ledger_entry_type as i64);
+        trace("} ");
 
-        let _ = trace("{ ");
-        let _ = trace("  -- Account Specific Fields");
+        trace("{ ");
+        trace("  -- Account Specific Fields");
 
         // Trace the `Account`
         let account_id = account.account().unwrap();
         // Account is the hardcoded ledger entry ID we're looking up - just verify it's 20 bytes
         test_utils::assert_eq!(account_id.0.len(), 20);
-        let _ = trace_data("  Account:", &account_id.0, DataRepr::AsHex);
+        trace_data("  Account:", &account_id.0, DataRepr::AsHex);
 
         // Trace the `AccountTxnID` (optional - required for testing)
         let account_txn_id_opt = account.account_txn_id().unwrap();
@@ -91,7 +91,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             account_txn_id_opt.expect("AccountTxnID should be present for testing");
         // AccountTxnID is system-generated - just verify it's 32 bytes
         test_utils::assert_eq!(account_txn_id.0.len(), 32);
-        let _ = trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
+        trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
 
         // Trace `AMMID` (optional - only present on AMM AccountRoot entries)
         // Note: This is a regular account, not an AMM account, so AMMID should be None
@@ -103,14 +103,14 @@ pub extern "C" fn escrow_finish() -> i32 {
 
         // Trace the `Balance` (required)
         let balance_amount = account.balance().unwrap();
-        let _ = trace_amt("Balance of Account Finishing the Escrow:", &balance_amount);
+        trace_amt("Balance of Account Finishing the Escrow:", &balance_amount);
         // NOTE: This is only available on WASM targets because in CI, the coverage test returns random memory
         // (whereas locally this returns the bytes 0x00).
         #[cfg(target_arch = "wasm32")]
         match balance_amount {
             Amount::XRP { num_drops } => {
                 // Balance is system-generated, just verify it's reasonable
-                let _ = trace_num("  Balance of Account Finishing the Escrow:", num_drops);
+                trace_num("  Balance of Account Finishing the Escrow:", num_drops);
             }
             Amount::IOU { .. } => {
                 panic!("IOU Balance encountered, but should have been XRP.")
@@ -123,7 +123,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         // Trace and assert the `BurnedNFTokens` (optional)
         let burned_nf_tokens_opt = account.burned_nftokens().unwrap();
         let burned_nf_tokens = burned_nf_tokens_opt.unwrap_or(0);
-        let _ = trace_num("  BurnedNFTokens:", burned_nf_tokens as i64);
+        trace_num("  BurnedNFTokens:", burned_nf_tokens as i64);
         test_utils::assert_eq!(burned_nf_tokens, 0, "Expected 0 burned NFTokens");
 
         // Trace the `Domain` (optional - required for testing)
@@ -137,7 +137,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             &expected_domain[..],
             "Domain should be 'example.com'"
         );
-        let _ = trace_data("  Domain:", &domain.data[..domain.len], DataRepr::AsHex);
+        trace_data("  Domain:", &domain.data[..domain.len], DataRepr::AsHex);
 
         // Trace the `EmailHash` (optional - required for testing)
         let email_hash_opt = account.email_hash().unwrap();
@@ -153,14 +153,14 @@ pub extern "C" fn escrow_finish() -> i32 {
             expected_email_hash,
             "EmailHash should be MD5 of 'hello'"
         );
-        let _ = trace_data("  EmailHash:", &email_hash.0, DataRepr::AsHex);
+        trace_data("  EmailHash:", &email_hash.0, DataRepr::AsHex);
 
         // Trace the `FirstNFTokenSequence` (optional - required for testing)
         let first_nf_token_sequence = account
             .first_nftoken_sequence()
             .unwrap()
             .expect("FirstNFTokenSequence should be set for testing");
-        let _ = trace_num("  FirstNFTokenSequence:", first_nf_token_sequence as i64);
+        trace_num("  FirstNFTokenSequence:", first_nf_token_sequence as i64);
 
         // Trace the `MessageKey` (optional - required for testing)
         let message_key_opt = account.message_key().unwrap();
@@ -177,7 +177,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             &expected_message_key,
             "MessageKey mismatch"
         );
-        let _ = trace_data(
+        trace_data(
             "  MessageKey:",
             &message_key.data[..message_key.len],
             DataRepr::AsHex,
@@ -190,7 +190,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             .expect("MintedNFTokens should be set for testing");
         // We minted exactly 1 NFToken in the test
         test_utils::assert_eq!(minted_nf_tokens, 1, "Expected 1 minted NFToken");
-        let _ = trace_num("  MintedNFTokens:", minted_nf_tokens as i64);
+        trace_num("  MintedNFTokens:", minted_nf_tokens as i64);
 
         // Trace the `NFTokenMinter` (optional - required for testing)
         let nf_token_minter = account
@@ -199,23 +199,23 @@ pub extern "C" fn escrow_finish() -> i32 {
             .expect("NFTokenMinter should be set for testing");
         // NFTokenMinter is an AccountID - verify it's 20 bytes
         test_utils::assert_eq!(nf_token_minter.0.len(), 20);
-        let _ = trace_data("  NFTokenMinter:", &nf_token_minter.0, DataRepr::AsHex);
+        trace_data("  NFTokenMinter:", &nf_token_minter.0, DataRepr::AsHex);
 
         // Trace the `OwnerCount` (required)
         let owner_count = account.owner_count().unwrap();
         // OwnerCount is system-generated based on owned objects
-        let _ = trace_num("  OwnerCount:", owner_count as i64);
+        trace_num("  OwnerCount:", owner_count as i64);
 
         // Trace the `PreviousTxnID` (required)
         let previous_txn_id = account.previous_txn_id().unwrap();
         // PreviousTxnID is system-generated - just verify it's 32 bytes
         test_utils::assert_eq!(previous_txn_id.0.len(), 32);
-        let _ = trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
+        trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
 
         // Trace the `PreviousTxnLgrSeq` (required)
         let previous_txn_lgr_seq = account.previous_txn_lgr_seq().unwrap();
         // PreviousTxnLgrSeq is system-generated
-        let _ = trace_num("  PreviousTxnLgrSeq:", previous_txn_lgr_seq as i64);
+        trace_num("  PreviousTxnLgrSeq:", previous_txn_lgr_seq as i64);
 
         // Trace the `RegularKey` (optional - required for testing)
         let regular_key = account
@@ -224,12 +224,12 @@ pub extern "C" fn escrow_finish() -> i32 {
             .expect("RegularKey should be set for testing");
         // RegularKey is an AccountID - verify it's 20 bytes
         test_utils::assert_eq!(regular_key.0.len(), 20);
-        let _ = trace_data("  RegularKey:", &regular_key.0, DataRepr::AsHex);
+        trace_data("  RegularKey:", &regular_key.0, DataRepr::AsHex);
 
         // Trace the `Sequence` (required)
         let sequence = account.sequence().unwrap();
         // Sequence is system-generated
-        let _ = trace_num("  Sequence:", sequence as i64);
+        trace_num("  Sequence:", sequence as i64);
 
         // Trace the `TicketCount` (optional - required for testing)
         let ticket_count = account
@@ -238,7 +238,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             .expect("TicketCount should be set for testing");
         // We created 5 tickets in the test
         test_utils::assert_eq!(ticket_count, 5, "Expected 5 tickets");
-        let _ = trace_num("  TicketCount:", ticket_count as i64);
+        trace_num("  TicketCount:", ticket_count as i64);
 
         // Trace the `TickSize` (optional - required for testing)
         let tick_size = account
@@ -247,7 +247,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             .expect("TickSize should be set for testing");
         // TickSize was set to 5 in the test
         test_utils::assert_eq!(tick_size, 5, "Expected TickSize to be 5");
-        let _ = trace_num("  TickSize:", tick_size as i64);
+        trace_num("  TickSize:", tick_size as i64);
 
         // Trace the `TransferRate` (optional - required for testing)
         let transfer_rate = account
@@ -260,7 +260,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             1002000000,
             "Expected TransferRate to be 1002000000"
         );
-        let _ = trace_num("  TransferRate:", transfer_rate as i64);
+        trace_num("  TransferRate:", transfer_rate as i64);
 
         // Trace the `WalletLocator` (optional - required for testing)
         let wallet_locator = account
@@ -275,13 +275,13 @@ pub extern "C" fn escrow_finish() -> i32 {
             expected_wallet_locator,
             "WalletLocator should be all 0xAA bytes"
         );
-        let _ = trace_data("  WalletLocator:", &wallet_locator.0, DataRepr::AsHex);
+        trace_data("  WalletLocator:", &wallet_locator.0, DataRepr::AsHex);
 
-        let _ = trace("}");
-        let _ = trace("");
+        trace("}");
+        trace("");
     }
 
-    let _ = trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
+    trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
     1 // <-- Finish the escrow to indicate a successful outcome
 }
 

--- a/e2e-tests/trace_escrow_finish/src/lib.rs
+++ b/e2e-tests/trace_escrow_finish/src/lib.rs
@@ -29,8 +29,8 @@ use xrpl_escrow_stdlib::current_tx::traits::EscrowFinishFields;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn escrow_finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
-    let _ = trace("");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("");
 
     // The transaction prompting execution of this contract.
     let escrow_finish: EscrowFinish = get_current_escrow_finish();
@@ -39,21 +39,21 @@ pub extern "C" fn escrow_finish() -> i32 {
     // Trace All EscrowFinish Fields
     // ########################################
     {
-        let _ = trace("### Trace All EscrowFinish Fields");
-        let _ = trace("{ ");
-        let _ = trace("  -- Common Fields");
+        trace("### Trace All EscrowFinish Fields");
+        trace("{ ");
+        trace("  -- Common Fields");
 
         // Trace Field: Account
         let account = escrow_finish.get_account().unwrap();
         // Account is the wallet that submitted the EscrowFinish - verify it's 20 bytes
         test_utils::assert_eq!(account.0.len(), 20);
-        let _ = trace_acct("  Account:", &account);
+        trace_acct("  Account:", &account);
 
         // Trace Field: TransactionType
         let transaction_type: TransactionType = escrow_finish.get_transaction_type().unwrap();
         test_utils::assert_eq!(transaction_type, TransactionType::EscrowFinish);
         let tx_type_bytes: [u8; 2] = transaction_type.into();
-        let _ = trace_data(
+        trace_data(
             "  TransactionType (EscrowFinish):",
             &tx_type_bytes,
             DataRepr::AsHex,
@@ -63,52 +63,52 @@ pub extern "C" fn escrow_finish() -> i32 {
         let gas: u32 = escrow_finish.get_gas().unwrap();
         test_utils::assert_eq!(gas, 1000000);
         // Gas is set in the transaction - just verify it's reasonable
-        let _ = trace_num("  Gas:", gas as i64);
+        trace_num("  Gas:", gas as i64);
 
         // Trace Field: Fee
         let fee = escrow_finish.get_fee().unwrap();
         // Fee is system-calculated, just trace it
-        let _ = trace_amt("  Fee:", &fee);
+        trace_amt("  Fee:", &fee);
 
         // Trace Field: Sequence
         let sequence: u32 = escrow_finish.get_sequence().unwrap();
         test_utils::assert!(sequence > 0);
         // Sequence is system-generated based on account state
-        let _ = trace_num("  Sequence:", sequence as i64);
+        trace_num("  Sequence:", sequence as i64);
 
         // Trace Field: AccountTxnID (optional)
         let opt_account_txn_id = escrow_finish.get_account_txn_id().unwrap();
         if let Some(account_txn_id) = opt_account_txn_id {
             // AccountTxnID is optional - if present, verify it's 32 bytes
             test_utils::assert_eq!(account_txn_id.0.len(), 32);
-            let _ = trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
+            trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
         }
 
         // Trace Field: Flags (optional)
         let opt_flags = escrow_finish.get_flags().unwrap();
         if let Some(flags) = opt_flags {
             // Flags are transaction-specific, just trace the value
-            let _ = trace_num("  Flags:", flags as i64);
+            trace_num("  Flags:", flags as i64);
         }
 
         // Trace Field: LastLedgerSequence (optional)
         let opt_last_ledger_sequence = escrow_finish.get_last_ledger_sequence().unwrap();
         if let Some(last_ledger_sequence) = opt_last_ledger_sequence {
             // LastLedgerSequence is optional, just trace it
-            let _ = trace_num("  LastLedgerSequence:", last_ledger_sequence as i64);
+            trace_num("  LastLedgerSequence:", last_ledger_sequence as i64);
         }
 
         // Trace Field: NetworkID (optional)
         let opt_network_id = escrow_finish.get_network_id().unwrap();
         if let Some(network_id) = opt_network_id {
             // NetworkID identifies the chain, just trace it
-            let _ = trace_num("  NetworkID:", network_id as i64);
+            trace_num("  NetworkID:", network_id as i64);
         }
 
         // Trace Field: SourceTag (optional - require it for testing)
         let opt_source_tag = escrow_finish.get_source_tag().unwrap();
         let source_tag = opt_source_tag.expect("SourceTag should be set for testing");
-        let _ = trace_num("  SourceTag:", source_tag as i64);
+        trace_num("  SourceTag:", source_tag as i64);
 
         // Trace Field: SigningPubKey
         // For multi-signed transactions, SigningPubKey is empty (0 bytes) and returns None
@@ -117,16 +117,16 @@ pub extern "C" fn escrow_finish() -> i32 {
         match signing_pub_key_result {
             host::Result::Ok(signing_pub_key_opt) => match signing_pub_key_opt {
                 Some(signing_pub_key) => {
-                    let _ = trace("  SigningPubKey (single-signed):");
-                    let _ = trace_num("    Length:", signing_pub_key.0.len() as i64);
-                    let _ = trace_data("    Data:", &signing_pub_key.0, DataRepr::AsHex);
+                    trace("  SigningPubKey (single-signed):");
+                    trace_num("    Length:", signing_pub_key.0.len() as i64);
+                    trace_data("    Data:", &signing_pub_key.0, DataRepr::AsHex);
                 }
                 None => {
-                    let _ = trace("  SigningPubKey: None (multi-signed transaction)");
+                    trace("  SigningPubKey: None (multi-signed transaction)");
                 }
             },
             host::Result::Err(e) => {
-                let _ = trace_num("  Error getting SigningPubKey, error_code = ", e as i64);
+                trace_num("  Error getting SigningPubKey, error_code = ", e as i64);
             }
         }
 
@@ -134,7 +134,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         let opt_ticket_sequence = escrow_finish.get_ticket_sequence().unwrap();
         if let Some(ticket_sequence) = opt_ticket_sequence {
             // TicketSequence is used instead of Sequence for ticket-based transactions
-            let _ = trace_num("  TicketSequence:", ticket_sequence as i64);
+            trace_num("  TicketSequence:", ticket_sequence as i64);
         }
 
         // Memos array (optional) - require at least one memo for testing
@@ -143,7 +143,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             array_len > 0,
             "At least one Memo should be present for testing"
         );
-        let _ = trace_num("  Memos array len:", array_len as i64);
+        trace_num("  Memos array len:", array_len as i64);
 
         for i in 0..array_len {
             let mut memo_buf = [0u8; 1024];
@@ -160,9 +160,9 @@ pub extern "C" fn escrow_finish() -> i32 {
                     memo_buf.len(),
                 )
             };
-            let _ = trace_num("    Memo #:", i as i64);
+            trace_num("    Memo #:", i as i64);
             if output_len > 0 {
-                let _ = trace_data(
+                trace_data(
                     "      MemoType:",
                     &memo_buf[..output_len as usize],
                     DataRepr::AsHex,
@@ -179,7 +179,7 @@ pub extern "C" fn escrow_finish() -> i32 {
                 )
             };
             if output_len > 0 {
-                let _ = trace_data(
+                trace_data(
                     "      MemoData:",
                     &memo_buf[..output_len as usize],
                     DataRepr::AsHex,
@@ -196,7 +196,7 @@ pub extern "C" fn escrow_finish() -> i32 {
                 )
             };
             if output_len > 0 {
-                let _ = trace_data(
+                trace_data(
                     "      MemoFormat:",
                     &memo_buf[..output_len as usize],
                     DataRepr::AsHex,
@@ -212,7 +212,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             array_len > 0,
             "At least one Signer should be present for testing"
         );
-        let _ = trace_num("  Signers array len:", array_len as i64);
+        trace_num("  Signers array len:", array_len as i64);
 
         for i in 0..array_len {
             let mut buf = [0x00; 128];
@@ -230,16 +230,16 @@ pub extern "C" fn escrow_finish() -> i32 {
                 )
             };
             if output_len < 0 {
-                let _ = trace_num("  cannot get Account, error:", output_len as i64);
+                trace_num("  cannot get Account, error:", output_len as i64);
                 panic!()
             }
-            let _ = trace_num("    Signer #:", i as i64);
+            trace_num("    Signer #:", i as i64);
             // Account should be 20 bytes
-            let _ = trace_num("     Account length:", output_len as i64);
+            trace_num("     Account length:", output_len as i64);
             if output_len == 20 {
-                let _ = trace_acct_buf("     Account:", &buf[..20].try_into().unwrap());
+                trace_acct_buf("     Account:", &buf[..20].try_into().unwrap());
             } else {
-                let _ = trace_data(
+                trace_data(
                     "     Account (unexpected length):",
                     &buf[..output_len as usize],
                     DataRepr::AsHex,
@@ -257,10 +257,10 @@ pub extern "C" fn escrow_finish() -> i32 {
                 )
             };
             if output_len < 0 {
-                let _ = trace_num("  cannot get TxnSignature, error:", output_len as i64);
+                trace_num("  cannot get TxnSignature, error:", output_len as i64);
                 panic!()
             }
-            let _ = trace_data(
+            trace_data(
                 "     TxnSignature:",
                 &buf[..output_len as usize],
                 DataRepr::AsHex,
@@ -276,15 +276,15 @@ pub extern "C" fn escrow_finish() -> i32 {
                 )
             };
             if output_len < 0 {
-                let _ = trace_num(
+                trace_num(
                     "     Error getting SigningPubKey. error_code = ",
                     output_len as i64,
                 );
                 panic!()
             }
             // SigningPubKey should be 33 bytes (compressed public key)
-            let _ = trace_num("     SigningPubKey length:", output_len as i64);
-            let _ = trace_data(
+            trace_num("     SigningPubKey length:", output_len as i64);
+            trace_data(
                 "     SigningPubKey:",
                 &buf[..output_len as usize],
                 DataRepr::AsHex,
@@ -295,38 +295,38 @@ pub extern "C" fn escrow_finish() -> i32 {
         // Multi-signed transactions use Signers array instead
         match escrow_finish.get_txn_signature() {
             host::Result::Ok(txn_signature) => {
-                let _ = trace("  TxnSignature (single-signed):");
-                let _ = trace_num("    Length:", txn_signature.len() as i64);
-                let _ = trace_data(
+                trace("  TxnSignature (single-signed):");
+                trace_num("    Length:", txn_signature.len() as i64);
+                trace_data(
                     "    Data:",
                     &txn_signature.data[..txn_signature.len()],
                     DataRepr::AsHex,
                 );
             }
             host::Result::Err(_) => {
-                let _ = trace("  TxnSignature not present (multi-signed transaction)");
+                trace("  TxnSignature not present (multi-signed transaction)");
             }
         }
 
-        let _ = trace("  -- EscrowFinish Fields");
+        trace("  -- EscrowFinish Fields");
 
         // Trace Field: Owner (required)
         let owner: AccountID = escrow_finish.get_owner().unwrap();
         // Owner is the account that created the escrow - verify it's 20 bytes
         test_utils::assert_eq!(owner.0.len(), 20);
-        let _ = trace_acct("  Owner:", &owner);
+        trace_acct("  Owner:", &owner);
 
         // Trace Field: OfferSequence (required)
         let offer_sequence: u32 = escrow_finish.get_offer_sequence().unwrap();
         // OfferSequence is the sequence number of the EscrowCreate transaction
-        let _ = trace_num("  OfferSequence:", offer_sequence as i64);
+        trace_num("  OfferSequence:", offer_sequence as i64);
 
         // Trace Field: Condition (optional)
         match escrow_finish.get_condition() {
             host::Result::Ok(opt_condition) => {
                 if let Some(condition) = opt_condition {
-                    let _ = trace_num("  Condition length:", condition.len() as i64);
-                    let _ = trace_data(
+                    trace_num("  Condition length:", condition.len() as i64);
+                    trace_data(
                         "  Condition (full hex):",
                         condition.as_slice(),
                         DataRepr::AsHex,
@@ -343,14 +343,14 @@ pub extern "C" fn escrow_finish() -> i32 {
                         &EXPECTED_CONDITION[..],
                         "Condition bytes mismatch"
                     );
-                    let _ = trace("  ✓ Condition matches expected value");
+                    trace("  ✓ Condition matches expected value");
                 } else {
-                    let _ = trace("  Condition: not present");
+                    trace("  Condition: not present");
                 }
             }
             host::Result::Err(e) => {
-                let _ = trace("  ERROR getting Condition");
-                let _ = trace_num("  error_code=", e as i64);
+                trace("  ERROR getting Condition");
+                trace_num("  error_code=", e as i64);
                 return e.code();
             }
         }
@@ -360,8 +360,8 @@ pub extern "C" fn escrow_finish() -> i32 {
         // in the EscrowFinish transaction (causes temMALFORMED). The Bytecode validates the condition.
         let opt_fulfillment = escrow_finish.get_fulfillment().unwrap();
         if let Some(fulfillment) = opt_fulfillment {
-            let _ = trace_num("  Fulfillment length:", fulfillment.len() as i64);
-            let _ = trace_data(
+            trace_num("  Fulfillment length:", fulfillment.len() as i64);
+            trace_data(
                 "  Fulfillment (hex):",
                 fulfillment.as_slice(),
                 DataRepr::AsHex,
@@ -378,12 +378,12 @@ pub extern "C" fn escrow_finish() -> i32 {
                 &EXPECTED_FULFILLMENT[..],
                 "Fulfillment bytes mismatch"
             );
-            let _ = trace("  ✓ Fulfillment matches expected value");
+            trace("  ✓ Fulfillment matches expected value");
 
             // Verify the fulfillment format
             // The Condition field in XRPL is just the 32-byte hash (not the full crypto-condition)
             // The Fulfillment should be a PREIMAGE-SHA-256 fulfillment in crypto-condition format
-            let _ = trace("  Verifying Fulfillment format...");
+            trace("  Verifying Fulfillment format...");
 
             // For PREIMAGE-SHA-256 fulfillment format: A002 80XX <preimage>
             // A002 = PREIMAGE-SHA-256 fulfillment type
@@ -391,12 +391,12 @@ pub extern "C" fn escrow_finish() -> i32 {
             // For empty preimage: A002 8000
             let fulfillment_data = fulfillment.as_slice();
             if fulfillment.len() >= 4 {
-                let _ = trace_data(
+                trace_data(
                     "    Fulfillment type tag:",
                     &fulfillment_data[0..2],
                     DataRepr::AsHex,
                 );
-                let _ = trace_data(
+                trace_data(
                     "    Preimage length encoding:",
                     &fulfillment_data[2..4],
                     DataRepr::AsHex,
@@ -405,15 +405,15 @@ pub extern "C" fn escrow_finish() -> i32 {
                 // Parse the preimage length
                 if fulfillment_data[2] == 0x80 {
                     let preimage_len = fulfillment_data[3] as usize;
-                    let _ = trace_num("    Preimage length:", preimage_len as i64);
+                    trace_num("    Preimage length:", preimage_len as i64);
 
                     if preimage_len == 0 {
-                        let _ = trace("    Preimage is empty (0 bytes)");
-                        let _ = trace(
+                        trace("    Preimage is empty (0 bytes)");
+                        trace(
                             "    Expected SHA-256 of empty string: E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
                         );
                     } else if fulfillment.len() >= 4 + preimage_len {
-                        let _ = trace_data(
+                        trace_data(
                             "    Preimage (hex):",
                             &fulfillment_data[4..4 + preimage_len],
                             DataRepr::AsHex,
@@ -422,7 +422,7 @@ pub extern "C" fn escrow_finish() -> i32 {
                 }
             }
         } else {
-            let _ = trace("  Fulfillment: not present (Bytecode validates condition)");
+            trace("  Fulfillment: not present (Bytecode validates condition)");
         }
 
         // As part of https://github.com/ripple/xrpl-wasm-stdlib/issues/91, we had the concept (for a minute) of a
@@ -434,21 +434,21 @@ pub extern "C" fn escrow_finish() -> i32 {
         // CredentialIDs (Vector256 - array of 256-bit hashes)
         // let opt_credential_ids = escrow_finish.get_credential_ids().unwrap();
         // if let Some(credential_ids) = opt_credential_ids {
-        //     let _ = trace_num("  Number of CredentialIDs:", credential_ids.len() as i64);
+        //     trace_num("  Number of CredentialIDs:", credential_ids.len() as i64);
         //     for i in 0..credential_ids.len() {
         //         let cred_id = credential_ids.get(i).unwrap();
-        //         let _ = trace_num("  CredentialID index:", i as i64);
-        //         let _ = trace_data("    CredentialID:", cred_id.as_bytes(), DataRepr::AsHex);
+        //         trace_num("  CredentialID index:", i as i64);
+        //         trace_data("    CredentialID:", cred_id.as_bytes(), DataRepr::AsHex);
         //     }
         // } else {
-        //     let _ = trace("  No CredentialIDs present");
+        //     trace("  No CredentialIDs present");
         // }
 
-        let _ = trace("}");
-        let _ = trace(""); // Newline
+        trace("}");
+        trace(""); // Newline
     }
 
-    let _ = trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
+    trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
     1 // <-- Finish the escrow to indicate a successful outcome
 }
 

--- a/e2e-tests/trace_escrow_finish/src/lib.rs
+++ b/e2e-tests/trace_escrow_finish/src/lib.rs
@@ -19,7 +19,7 @@ use xrpl_common_stdlib::current_tx::traits::TransactionCommonFields;
 use xrpl_common_stdlib::fields::locator::Locator;
 use xrpl_common_stdlib::host;
 use xrpl_common_stdlib::host::trace::{
-    DataRepr, trace, trace_acct, trace_acct_buf, trace_amt, trace_data, trace_num,
+    trace, trace_acct, trace_acct_buf, trace_amt, trace_hex, trace_num,
 };
 use xrpl_common_stdlib::sfield;
 use xrpl_common_stdlib::types::account_id::AccountID;
@@ -53,11 +53,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         let transaction_type: TransactionType = escrow_finish.get_transaction_type().unwrap();
         test_utils::assert_eq!(transaction_type, TransactionType::EscrowFinish);
         let tx_type_bytes: [u8; 2] = transaction_type.into();
-        trace_data(
-            "  TransactionType (EscrowFinish):",
-            &tx_type_bytes,
-            DataRepr::AsHex,
-        );
+        trace_hex("  TransactionType (EscrowFinish):", &tx_type_bytes);
 
         // Trace Field: Gas
         let gas: u32 = escrow_finish.get_gas().unwrap();
@@ -81,7 +77,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         if let Some(account_txn_id) = opt_account_txn_id {
             // AccountTxnID is optional - if present, verify it's 32 bytes
             test_utils::assert_eq!(account_txn_id.0.len(), 32);
-            trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
+            trace_hex("  AccountTxnID:", &account_txn_id.0);
         }
 
         // Trace Field: Flags (optional)
@@ -119,7 +115,7 @@ pub extern "C" fn escrow_finish() -> i32 {
                 Some(signing_pub_key) => {
                     trace("  SigningPubKey (single-signed):");
                     trace_num("    Length:", signing_pub_key.0.len() as i64);
-                    trace_data("    Data:", &signing_pub_key.0, DataRepr::AsHex);
+                    trace_hex("    Data:", &signing_pub_key.0);
                 }
                 None => {
                     trace("  SigningPubKey: None (multi-signed transaction)");
@@ -162,11 +158,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             };
             trace_num("    Memo #:", i as i64);
             if output_len > 0 {
-                trace_data(
-                    "      MemoType:",
-                    &memo_buf[..output_len as usize],
-                    DataRepr::AsHex,
-                );
+                trace_hex("      MemoType:", &memo_buf[..output_len as usize]);
             }
 
             locator.repack_last(sfield::MemoData);
@@ -179,11 +171,7 @@ pub extern "C" fn escrow_finish() -> i32 {
                 )
             };
             if output_len > 0 {
-                trace_data(
-                    "      MemoData:",
-                    &memo_buf[..output_len as usize],
-                    DataRepr::AsHex,
-                );
+                trace_hex("      MemoData:", &memo_buf[..output_len as usize]);
             }
 
             locator.repack_last(sfield::MemoFormat);
@@ -196,11 +184,7 @@ pub extern "C" fn escrow_finish() -> i32 {
                 )
             };
             if output_len > 0 {
-                trace_data(
-                    "      MemoFormat:",
-                    &memo_buf[..output_len as usize],
-                    DataRepr::AsHex,
-                );
+                trace_hex("      MemoFormat:", &memo_buf[..output_len as usize]);
             }
         }
 
@@ -239,10 +223,9 @@ pub extern "C" fn escrow_finish() -> i32 {
             if output_len == 20 {
                 trace_acct_buf("     Account:", &buf[..20].try_into().unwrap());
             } else {
-                trace_data(
+                trace_hex(
                     "     Account (unexpected length):",
                     &buf[..output_len as usize],
-                    DataRepr::AsHex,
                 );
                 panic!()
             }
@@ -260,11 +243,7 @@ pub extern "C" fn escrow_finish() -> i32 {
                 trace_num("  cannot get TxnSignature, error:", output_len as i64);
                 panic!()
             }
-            trace_data(
-                "     TxnSignature:",
-                &buf[..output_len as usize],
-                DataRepr::AsHex,
-            );
+            trace_hex("     TxnSignature:", &buf[..output_len as usize]);
 
             locator.repack_last(sfield::SigningPubKey);
             let output_len = unsafe {
@@ -284,11 +263,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             }
             // SigningPubKey should be 33 bytes (compressed public key)
             trace_num("     SigningPubKey length:", output_len as i64);
-            trace_data(
-                "     SigningPubKey:",
-                &buf[..output_len as usize],
-                DataRepr::AsHex,
-            );
+            trace_hex("     SigningPubKey:", &buf[..output_len as usize]);
         }
 
         // TxnSignature - only present for single-signed transactions
@@ -297,11 +272,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             host::Result::Ok(txn_signature) => {
                 trace("  TxnSignature (single-signed):");
                 trace_num("    Length:", txn_signature.len() as i64);
-                trace_data(
-                    "    Data:",
-                    &txn_signature.data[..txn_signature.len()],
-                    DataRepr::AsHex,
-                );
+                trace_hex("    Data:", &txn_signature.data[..txn_signature.len()]);
             }
             host::Result::Err(_) => {
                 trace("  TxnSignature not present (multi-signed transaction)");
@@ -326,11 +297,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             host::Result::Ok(opt_condition) => {
                 if let Some(condition) = opt_condition {
                     trace_num("  Condition length:", condition.len() as i64);
-                    trace_data(
-                        "  Condition (full hex):",
-                        condition.as_slice(),
-                        DataRepr::AsHex,
-                    );
+                    trace_hex("  Condition (full hex):", condition.as_slice());
 
                     // Assert the condition matches the expected value
                     test_utils::assert_eq!(
@@ -361,11 +328,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         let opt_fulfillment = escrow_finish.get_fulfillment().unwrap();
         if let Some(fulfillment) = opt_fulfillment {
             trace_num("  Fulfillment length:", fulfillment.len() as i64);
-            trace_data(
-                "  Fulfillment (hex):",
-                fulfillment.as_slice(),
-                DataRepr::AsHex,
-            );
+            trace_hex("  Fulfillment (hex):", fulfillment.as_slice());
 
             // Assert the fulfillment matches the expected value
             test_utils::assert_eq!(
@@ -391,16 +354,8 @@ pub extern "C" fn escrow_finish() -> i32 {
             // For empty preimage: A002 8000
             let fulfillment_data = fulfillment.as_slice();
             if fulfillment.len() >= 4 {
-                trace_data(
-                    "    Fulfillment type tag:",
-                    &fulfillment_data[0..2],
-                    DataRepr::AsHex,
-                );
-                trace_data(
-                    "    Preimage length encoding:",
-                    &fulfillment_data[2..4],
-                    DataRepr::AsHex,
-                );
+                trace_hex("    Fulfillment type tag:", &fulfillment_data[0..2]);
+                trace_hex("    Preimage length encoding:", &fulfillment_data[2..4]);
 
                 // Parse the preimage length
                 if fulfillment_data[2] == 0x80 {
@@ -413,10 +368,9 @@ pub extern "C" fn escrow_finish() -> i32 {
                             "    Expected SHA-256 of empty string: E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855",
                         );
                     } else if fulfillment.len() >= 4 + preimage_len {
-                        trace_data(
+                        trace_hex(
                             "    Preimage (hex):",
                             &fulfillment_data[4..4 + preimage_len],
-                            DataRepr::AsHex,
                         );
                     }
                 }
@@ -438,7 +392,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         //     for i in 0..credential_ids.len() {
         //         let cred_id = credential_ids.get(i).unwrap();
         //         trace_num("  CredentialID index:", i as i64);
-        //         trace_data("    CredentialID:", cred_id.as_bytes(), DataRepr::AsHex);
+        //         trace_hex("    CredentialID:", cred_id.as_bytes());
         //     }
         // } else {
         //     trace("  No CredentialIDs present");

--- a/e2e-tests/trace_escrow_ledger_object/src/lib.rs
+++ b/e2e-tests/trace_escrow_ledger_object/src/lib.rs
@@ -30,8 +30,8 @@ use xrpl_escrow_stdlib::ledger_objects::traits::CurrentEscrowFields;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn escrow_finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
-    let _ = trace("");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("");
 
     let current_escrow: CurrentEscrow = get_current_escrow();
 
@@ -39,35 +39,35 @@ pub extern "C" fn escrow_finish() -> i32 {
     // Trace All Current Escrow Ledger Object Fields
     // ########################################
     {
-        let _ = trace("### Trace Current Escrow Ledger Object Fields");
-        let _ = trace("{ ");
-        let _ = trace("  -- Common Fields");
+        trace("### Trace Current Escrow Ledger Object Fields");
+        trace("{ ");
+        trace("  -- Common Fields");
 
         // Trace Field: Account
         let account = current_escrow.get_account().unwrap();
         test_utils::assert_eq!(account.0.len(), 20);
-        let _ = trace_data("  Account:", &account.0, DataRepr::AsHex);
+        trace_data("  Account:", &account.0, DataRepr::AsHex);
 
         // Trace Field: Amount
         let amount = current_escrow.get_amount().unwrap();
-        let _ = trace_amt("  Amount:", &amount);
+        trace_amt("  Amount:", &amount);
 
         // Trace Field: LedgerEntryType
         let ledger_entry_type = current_escrow.get_ledger_entry_type().unwrap();
         test_utils::assert_eq!(ledger_entry_type, 117);
-        let _ = trace_num("  LedgerEntryType:", ledger_entry_type as i64);
+        trace_num("  LedgerEntryType:", ledger_entry_type as i64);
 
         // Trace Field: CancelAfter (optional - require it for testing)
         let opt_cancel_after = current_escrow.get_cancel_after().unwrap();
         let cancel_after = opt_cancel_after.expect("CancelAfter should be set for testing");
-        let _ = trace_num("  CancelAfter:", cancel_after as i64);
+        trace_num("  CancelAfter:", cancel_after as i64);
 
         // Trace Field: Condition (optional)
         match current_escrow.get_condition() {
             Ok(opt_condition) => {
                 if let Some(condition) = opt_condition {
-                    let _ = trace_num("  Condition length:", condition.len() as i64);
-                    let _ = trace_data(
+                    trace_num("  Condition length:", condition.len() as i64);
+                    trace_data(
                         "  Condition (full hex):",
                         condition.as_slice(),
                         DataRepr::AsHex,
@@ -83,14 +83,14 @@ pub extern "C" fn escrow_finish() -> i32 {
                         &EXPECTED_CONDITION[..],
                         "Condition bytes mismatch"
                     );
-                    let _ = trace("  ✓ Condition matches expected value");
+                    trace("  ✓ Condition matches expected value");
                 } else {
-                    let _ = trace("  Condition: not present");
+                    trace("  Condition: not present");
                 }
             }
             Err(e) => {
-                let _ = trace("  ERROR getting Condition");
-                let _ = trace_num("  error_code=", e as i64);
+                trace("  ERROR getting Condition");
+                trace_num("  error_code=", e as i64);
                 return e.code();
             }
         }
@@ -99,27 +99,27 @@ pub extern "C" fn escrow_finish() -> i32 {
         let destination = current_escrow.get_destination().unwrap();
         // Destination is set in runTest.js (destWallet), just verify it's a valid AccountID
         test_utils::assert_eq!(destination.0.len(), 20);
-        let _ = trace_data("  Destination:", &destination.0, DataRepr::AsHex);
+        trace_data("  Destination:", &destination.0, DataRepr::AsHex);
 
         // Trace Field: DestinationTag (optional - already set in runTest.js)
         let opt_destination_tag = current_escrow.get_destination_tag().unwrap();
         let destination_tag =
             opt_destination_tag.expect("DestinationTag should be set for testing");
         test_utils::assert_eq!(destination_tag, 23480);
-        let _ = trace_num("  DestinationTag:", destination_tag as i64);
+        trace_num("  DestinationTag:", destination_tag as i64);
 
         // Trace Field: FinishAfter (optional - require it for testing)
         let opt_finish_after = current_escrow.get_finish_after().unwrap();
         let finish_after = opt_finish_after.expect("FinishAfter should be set for testing");
-        let _ = trace_num("  FinishAfter:", finish_after as i64);
+        trace_num("  FinishAfter:", finish_after as i64);
 
         // Trace Field: Flags
         let result = current_escrow.get_flags();
         if let Ok(flags) = result {
             // Flags is typically 0 for escrows
-            let _ = trace_num("  Flags:", flags as i64);
+            trace_num("  Flags:", flags as i64);
         } else if let Err(error) = result {
-            let _ = trace_num("  Error getting Flags. error_code = ", error.code() as i64);
+            trace_num("  Error getting Flags. error_code = ", error.code() as i64);
         }
 
         // TODO: Uncomment this once https://github.com/ripple/xrpl-wasm-stdlib/issues/86 is fixed.
@@ -127,8 +127,8 @@ pub extern "C" fn escrow_finish() -> i32 {
         // let opt_bytecode = current_escrow.get_bytecode().unwrap();
         // if let Some(bytecode) = opt_bytecode {
         //     Bytecode is the WASM code - just verify it exists and has reasonable length
-        // let _ = trace_num("  Bytecode length:", bytecode.len as i64);
-        // let _ = trace_data(
+        // trace_num("  Bytecode length:", bytecode.len as i64);
+        // trace_data(
         //     "  Bytecode:",
         //     &bytecode.data[..bytecode.len],
         //     DataRepr::AsHex,
@@ -138,15 +138,15 @@ pub extern "C" fn escrow_finish() -> i32 {
         // Trace Field: OwnerNode
         let owner_node = current_escrow.get_owner_node().unwrap();
         // OwnerNode is system-generated, typically 0 for first entry
-        let _ = trace_num("  OwnerNode:", owner_node as i64);
+        trace_num("  OwnerNode:", owner_node as i64);
 
         // Trace Field: DestinationNode (optional - system-generated, may or may not be present)
         let opt_destination_node = current_escrow.get_destination_node().unwrap();
         if let Some(destination_node) = opt_destination_node {
             // DestinationNode is system-generated, typically 0 for first entry
-            let _ = trace_num("  DestinationNode:", destination_node as i64);
+            trace_num("  DestinationNode:", destination_node as i64);
         } else {
-            let _ = trace("  DestinationNode: not present");
+            trace("  DestinationNode: not present");
         }
 
         // Trace Field: PreviousTxnID
@@ -154,18 +154,18 @@ pub extern "C" fn escrow_finish() -> i32 {
         // PreviousTxnID is the hash of the EscrowCreate transaction - unpredictable
         // Just verify it's 32 bytes (valid Hash256)
         test_utils::assert_eq!(previous_txn_id.0.len(), 32);
-        let _ = trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
+        trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
 
         // Trace Field: PreviousTxnLgrSeq
         let previous_txn_lgr_seq = current_escrow.get_previous_txn_lgr_seq().unwrap();
         // PreviousTxnLgrSeq is system-generated - just verify it's non-zero
-        let _ = trace_num("  PreviousTxnLgrSeq:", previous_txn_lgr_seq as i64);
+        trace_num("  PreviousTxnLgrSeq:", previous_txn_lgr_seq as i64);
 
         // Trace Field: SourceTag (optional - already set in runTest.js)
         let opt_source_tag = current_escrow.get_source_tag().unwrap();
         let source_tag = opt_source_tag.expect("SourceTag should be set for testing");
         test_utils::assert_eq!(source_tag, 11747);
-        let _ = trace_num("  SourceTag:", source_tag as i64);
+        trace_num("  SourceTag:", source_tag as i64);
 
         // Trace Field: Data (contract data)
         // Note: Data field is optional and only present if set during EscrowCreate or
@@ -175,16 +175,16 @@ pub extern "C" fn escrow_finish() -> i32 {
         if let Ok(contract_data) = data_result
             && contract_data.len > 0
         {
-            let _ = trace_num("  Data length:", contract_data.len as i64);
-            let _ = trace_data(
+            trace_num("  Data length:", contract_data.len as i64);
+            trace_data(
                 "  Data:",
                 &contract_data.data[..contract_data.len],
                 DataRepr::AsHex,
             );
         }
 
-        let _ = trace("}");
-        let _ = trace("");
+        trace("}");
+        trace("");
     }
 
     // ########################################
@@ -196,7 +196,7 @@ pub extern "C" fn escrow_finish() -> i32 {
     // getter above — that equality is what proves the locator encoding and the host dispatch are
     // both correct against a real ledger object, not just against mocks.
     {
-        let _ = trace("### Current Escrow Ledger Object Fields via path()");
+        trace("### Current Escrow Ledger Object Fields via path()");
 
         // Path Read: Account
         let path_account = current_escrow
@@ -205,7 +205,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             .get::<AccountID>()
             .unwrap();
         test_utils::assert_eq!(path_account.0, current_escrow.get_account().unwrap().0);
-        let _ = trace_data("  Account (via path):", &path_account.0, DataRepr::AsHex);
+        trace_data("  Account (via path):", &path_account.0, DataRepr::AsHex);
 
         // Path Read: OwnerNode
         let path_owner_node = current_escrow
@@ -214,7 +214,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             .get::<u64>()
             .unwrap();
         test_utils::assert_eq!(path_owner_node, current_escrow.get_owner_node().unwrap());
-        let _ = trace_num("  OwnerNode (via path):", path_owner_node as i64);
+        trace_num("  OwnerNode (via path):", path_owner_node as i64);
 
         // Path Read: PreviousTxnLgrSeq
         let path_prev_lgr_seq = current_escrow
@@ -226,7 +226,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             path_prev_lgr_seq,
             current_escrow.get_previous_txn_lgr_seq().unwrap()
         );
-        let _ = trace_num("  PreviousTxnLgrSeq (via path):", path_prev_lgr_seq as i64);
+        trace_num("  PreviousTxnLgrSeq (via path):", path_prev_lgr_seq as i64);
 
         // Path Read: DestinationTag, an optional field that runTest.js does set. Both routes must
         // agree it is present, and agree on the value.
@@ -239,7 +239,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         test_utils::assert!(path_dest_tag.is_some());
         test_utils::assert!(flat_dest_tag.is_some());
         test_utils::assert_eq!(path_dest_tag.unwrap(), flat_dest_tag.unwrap());
-        let _ = trace_num(
+        trace_num(
             "  DestinationTag (via path):",
             path_dest_tag.unwrap() as i64,
         );
@@ -257,18 +257,18 @@ pub extern "C" fn escrow_finish() -> i32 {
         let non_array_len = current_escrow.path().field(sfield::Account).array_len();
         match non_array_len {
             Ok(len) => {
-                let _ = trace_num("  array_len on non-array returned:", len as i64);
+                trace_num("  array_len on non-array returned:", len as i64);
             }
             Err(error) => {
-                let _ = trace_num("  array_len on non-array errored:", error.code() as i64);
+                trace_num("  array_len on non-array errored:", error.code() as i64);
             }
         }
         test_utils::assert!(non_array_len.is_err());
 
-        let _ = trace("");
+        trace("");
     }
 
-    let _ = trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
+    trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
     1 // <-- Finish the escrow to indicate a successful outcome
 }
 

--- a/e2e-tests/trace_escrow_ledger_object/src/lib.rs
+++ b/e2e-tests/trace_escrow_ledger_object/src/lib.rs
@@ -20,7 +20,7 @@ const EXPECTED_CONDITION: [u8; 39] = [
     0x4C, 0x65, 0xE5, 0xE3, 0x81, 0x01, 0x03,
 ];
 
-use xrpl_common_stdlib::host::trace::{DataRepr, trace, trace_amt, trace_data, trace_num};
+use xrpl_common_stdlib::host::trace::{trace, trace_amt, trace_hex, trace_num};
 use xrpl_common_stdlib::host::{Result::Err, Result::Ok};
 use xrpl_common_stdlib::objects::traits::CurrentLedgerObjectCommonFields;
 use xrpl_common_stdlib::sfield;
@@ -46,7 +46,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         // Trace Field: Account
         let account = current_escrow.get_account().unwrap();
         test_utils::assert_eq!(account.0.len(), 20);
-        trace_data("  Account:", &account.0, DataRepr::AsHex);
+        trace_hex("  Account:", &account.0);
 
         // Trace Field: Amount
         let amount = current_escrow.get_amount().unwrap();
@@ -67,11 +67,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             Ok(opt_condition) => {
                 if let Some(condition) = opt_condition {
                     trace_num("  Condition length:", condition.len() as i64);
-                    trace_data(
-                        "  Condition (full hex):",
-                        condition.as_slice(),
-                        DataRepr::AsHex,
-                    );
+                    trace_hex("  Condition (full hex):", condition.as_slice());
 
                     test_utils::assert_eq!(
                         condition.len(),
@@ -99,7 +95,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         let destination = current_escrow.get_destination().unwrap();
         // Destination is set in runTest.js (destWallet), just verify it's a valid AccountID
         test_utils::assert_eq!(destination.0.len(), 20);
-        trace_data("  Destination:", &destination.0, DataRepr::AsHex);
+        trace_hex("  Destination:", &destination.0);
 
         // Trace Field: DestinationTag (optional - already set in runTest.js)
         let opt_destination_tag = current_escrow.get_destination_tag().unwrap();
@@ -128,10 +124,9 @@ pub extern "C" fn escrow_finish() -> i32 {
         // if let Some(bytecode) = opt_bytecode {
         //     Bytecode is the WASM code - just verify it exists and has reasonable length
         // trace_num("  Bytecode length:", bytecode.len as i64);
-        // trace_data(
+        // trace_hex(
         //     "  Bytecode:",
         //     &bytecode.data[..bytecode.len],
-        //     DataRepr::AsHex,
         // );
         // }
 
@@ -154,7 +149,7 @@ pub extern "C" fn escrow_finish() -> i32 {
         // PreviousTxnID is the hash of the EscrowCreate transaction - unpredictable
         // Just verify it's 32 bytes (valid Hash256)
         test_utils::assert_eq!(previous_txn_id.0.len(), 32);
-        trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
+        trace_hex("  PreviousTxnID:", &previous_txn_id.0);
 
         // Trace Field: PreviousTxnLgrSeq
         let previous_txn_lgr_seq = current_escrow.get_previous_txn_lgr_seq().unwrap();
@@ -176,11 +171,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             && contract_data.len > 0
         {
             trace_num("  Data length:", contract_data.len as i64);
-            trace_data(
-                "  Data:",
-                &contract_data.data[..contract_data.len],
-                DataRepr::AsHex,
-            );
+            trace_hex("  Data:", &contract_data.data[..contract_data.len]);
         }
 
         trace("}");
@@ -205,7 +196,7 @@ pub extern "C" fn escrow_finish() -> i32 {
             .get::<AccountID>()
             .unwrap();
         test_utils::assert_eq!(path_account.0, current_escrow.get_account().unwrap().0);
-        trace_data("  Account (via path):", &path_account.0, DataRepr::AsHex);
+        trace_hex("  Account (via path):", &path_account.0);
 
         // Path Read: OwnerNode
         let path_owner_node = current_escrow

--- a/examples/smart-escrows/atomic_swap/atomic_swap1/src/lib.rs
+++ b/examples/smart-escrows/atomic_swap/atomic_swap1/src/lib.rs
@@ -150,7 +150,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     let counterpart_data = match counterpart_escrow.data() {
         Ok(Some(data)) => data,
         Ok(None) => {
-            let _ = trace_num("Counterpart escrow has no data field", 0);
+            trace_num("Counterpart escrow has no data field", 0);
             return VALIDATION_FAILED;
         }
         Err(e) => {

--- a/examples/smart-escrows/atomic_swap/atomic_swap1/src/lib.rs
+++ b/examples/smart-escrows/atomic_swap/atomic_swap1/src/lib.rs
@@ -96,14 +96,14 @@ pub fn get_first_memo() -> Result<Option<(ContractData, usize)>> {
 /// 5. Stores the counterpart ledger entry ID + deadline in the data field
 /// 6. Returns 0 to wait for Phase 2
 fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
-    let _ = trace_num("Phase 1: Initialization", 0);
+    trace_num("Phase 1: Initialization", 0);
 
     // Extract the counterpart escrow ledger entry ID from transaction memo
     let (memo, memo_len) = match get_first_memo() {
         Ok(v) => match v {
             Some(v) => v,
             None => {
-                let _ = trace_num(
+                trace_num(
                     "No memo provided - atomic swap requires counterpart reference",
                     0,
                 );
@@ -111,21 +111,21 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
             }
         },
         Err(e) => {
-            let _ = trace_num("Error getting first memo:", e.code() as i64);
+            trace_num("Error getting first memo:", e.code() as i64);
             return e.code();
         }
     };
 
     // Validate memo contains a full 32-byte ledger entry ID
     if memo_len != XRPL_LEDGER_ENTRY_ID_SIZE {
-        let _ = trace_num("Memo too short, expected 32 bytes, got:", memo_len as i64);
+        trace_num("Memo too short, expected 32 bytes, got:", memo_len as i64);
         return VALIDATION_FAILED;
     }
 
     // Extract the counterpart escrow ledger entry ID (first 32 bytes of memo)
     let counterpart_escrow_id: [u8; XRPL_LEDGER_ENTRY_ID_SIZE] =
         memo.data[0..32].try_into().unwrap();
-    let _ = trace_data(
+    trace_data(
         "Counterpart escrow ID from memo:",
         &counterpart_escrow_id,
         DataRepr::AsHex,
@@ -140,7 +140,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
         )
     };
     if counterpart_slot < 0 {
-        let _ = trace_num(
+        trace_num(
             "Failed to cache counterpart escrow, error:",
             counterpart_slot as i64,
         );
@@ -148,7 +148,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     }
 
     let counterpart_escrow = Escrow::new(counterpart_slot);
-    let _ = trace_num("Starting counterpart security validation", 0);
+    trace_num("Starting counterpart security validation", 0);
 
     // Data Field Validation: Verify counterpart's data field structure
     let counterpart_data = match counterpart_escrow.data() {
@@ -158,7 +158,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
             return VALIDATION_FAILED;
         }
         Err(e) => {
-            let _ = trace_num("Error getting counterpart data:", e.code() as i64);
+            trace_num("Error getting counterpart data:", e.code() as i64);
             return e.code();
         }
     };
@@ -167,14 +167,14 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     if counterpart_data.len != XRPL_LEDGER_ENTRY_ID_SIZE
         && counterpart_data.len != LEDGER_ENTRY_ID_PLUS_TIMESTAMP_SIZE
     {
-        let _ = trace_num(
+        trace_num(
             "Counterpart data field invalid length, expected 32 or 36 bytes, got:",
             counterpart_data.len as i64,
         );
         return VALIDATION_FAILED;
     }
 
-    let _ = trace_data(
+    trace_data(
         "Counterpart data field:",
         &counterpart_data.data[0..counterpart_data.len],
         DataRepr::AsHex,
@@ -184,7 +184,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     let current_account = match current_escrow.get_account() {
         Ok(account) => account,
         Err(e) => {
-            let _ = trace_num("Error getting current escrow account:", e.code() as i64);
+            trace_num("Error getting current escrow account:", e.code() as i64);
             return e.code();
         }
     };
@@ -192,7 +192,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     let current_destination = match current_escrow.get_destination() {
         Ok(destination) => destination,
         Err(e) => {
-            let _ = trace_num("Error getting current escrow destination:", e.code() as i64);
+            trace_num("Error getting current escrow destination:", e.code() as i64);
             return e.code();
         }
     };
@@ -201,7 +201,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     let counterpart_account = match counterpart_escrow.account() {
         Ok(account) => account,
         Err(e) => {
-            let _ = trace_num("Error getting counterpart escrow account:", e.code() as i64);
+            trace_num("Error getting counterpart escrow account:", e.code() as i64);
             return e.code();
         }
     };
@@ -209,7 +209,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     let counterpart_destination = match counterpart_escrow.destination() {
         Ok(destination) => destination,
         Err(e) => {
-            let _ = trace_num(
+            trace_num(
                 "Error getting counterpart escrow destination:",
                 e.code() as i64,
             );
@@ -219,8 +219,8 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
 
     // ATOMIC SWAP VALIDATION: Verify inverted account correlations
     if current_account.0 != counterpart_destination.0 {
-        let _ = trace_data("Current account:", &current_account.0, DataRepr::AsHex);
-        let _ = trace_data(
+        trace_data("Current account:", &current_account.0, DataRepr::AsHex);
+        trace_data(
             "Expected counterpart destination:",
             &counterpart_destination.0,
             DataRepr::AsHex,
@@ -229,12 +229,12 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     }
 
     if current_destination.0 != counterpart_account.0 {
-        let _ = trace_data(
+        trace_data(
             "Current destination:",
             &current_destination.0,
             DataRepr::AsHex,
         );
-        let _ = trace_data(
+        trace_data(
             "Expected counterpart account:",
             &counterpart_account.0,
             DataRepr::AsHex,
@@ -242,22 +242,22 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
         return VALIDATION_FAILED;
     }
 
-    let _ = trace_num("All counterpart security validations passed", 0);
+    trace_num("All counterpart security validations passed", 0);
 
     // Get current escrow's CancelAfter field - this becomes our swap deadline
     let cancel_after = match current_escrow.get_cancel_after() {
         Ok(Some(cancel_after)) => cancel_after,
         Ok(None) => {
-            let _ = trace_num("Current escrow has no CancelAfter field", 0);
+            trace_num("Current escrow has no CancelAfter field", 0);
             return VALIDATION_FAILED;
         }
         Err(e) => {
-            let _ = trace_num("Error getting CancelAfter:", e.code() as i64);
+            trace_num("Error getting CancelAfter:", e.code() as i64);
             return e.code();
         }
     };
 
-    let _ = trace_num("Current escrow CancelAfter:", cancel_after as i64);
+    trace_num("Current escrow CancelAfter:", cancel_after as i64);
 
     // Build new data field: counterpart ledger entry ID (32 bytes) + CancelAfter (4 bytes)
     let mut new_data = xrpl_common_stdlib::types::contract_data::ContractData {
@@ -270,8 +270,8 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
         .copy_from_slice(&cancel_after_bytes);
     new_data.len = LEDGER_ENTRY_ID_PLUS_TIMESTAMP_SIZE;
 
-    let _ = trace_num("Updated data length:", new_data.len as i64);
-    let _ = trace_data(
+    trace_num("Updated data length:", new_data.len as i64);
+    trace_data(
         "Updated data:",
         &new_data.data[0..new_data.len],
         DataRepr::AsHex,
@@ -280,16 +280,16 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     // Persist the updated data field to the escrow object
     match <CurrentEscrow as CurrentEscrowFields>::update_current_escrow_data(new_data) {
         Ok(()) => {
-            let _ = trace_num("Successfully updated escrow data", 0);
+            trace_num("Successfully updated escrow data", 0);
         }
         Err(e) => {
-            let _ = trace_num("Error updating escrow data:", e.code() as i64);
+            trace_num("Error updating escrow data:", e.code() as i64);
             return e.code();
         }
     }
 
     // Return 0 (failure) to indicate phase 1 complete, wait for phase 2
-    let _ = trace_num("Phase 1 complete - waiting for Phase 2", 0);
+    trace_num("Phase 1 complete - waiting for Phase 2", 0);
     0
 }
 
@@ -301,11 +301,11 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
 /// 3. Validates that current time < CancelAfter (within deadline)
 /// 4. Returns 1 (success) if within deadline, 0 (failure) if expired
 fn phase2_complete(current_data: &xrpl_common_stdlib::types::contract_data::ContractData) -> i32 {
-    let _ = trace_num("Phase 2: Timing validation", 0);
+    trace_num("Phase 2: Timing validation", 0);
 
     // Validate data field contains at least 36 bytes (32 bytes ledger entry ID + 4 bytes timing)
     if current_data.len < LEDGER_ENTRY_ID_PLUS_TIMESTAMP_SIZE {
-        let _ = trace_num(
+        trace_num(
             "Invalid data length for Phase 2, expected at least 36 bytes, got:",
             current_data.len as i64,
         );
@@ -318,7 +318,7 @@ fn phase2_complete(current_data: &xrpl_common_stdlib::types::contract_data::Cont
         .try_into()
         .unwrap();
     let cancel_after = u32::from_le_bytes(cancel_after_bytes);
-    let _ = trace_num("Extracted CancelAfter:", cancel_after as i64);
+    trace_num("Extracted CancelAfter:", cancel_after as i64);
 
     // Get current ledger time for deadline comparison
     let mut time_buffer = [0u8; 4];
@@ -330,19 +330,19 @@ fn phase2_complete(current_data: &xrpl_common_stdlib::types::contract_data::Cont
     }) {
         Ok(time) => time,
         Err(e) => {
-            let _ = trace_num("Failed to get parent ledger time:", e.code() as i64);
+            trace_num("Failed to get parent ledger time:", e.code() as i64);
             return VALIDATION_FAILED;
         }
     };
 
-    let _ = trace_num("Current ledger time:", current_time as i64);
+    trace_num("Current ledger time:", current_time as i64);
 
     // ATOMIC SWAP TIMING VALIDATION
     if current_time < cancel_after {
-        let _ = trace_num("Atomic swap executed before CancelAfter - success!", 0);
+        trace_num("Atomic swap executed before CancelAfter - success!", 0);
         1 // Success - escrow completes within deadline
     } else {
-        let _ = trace_num("Atomic swap attempted after CancelAfter - failed", 0);
+        trace_num("Atomic swap attempted after CancelAfter - failed", 0);
         0 // Failure - deadline exceeded, swap expired
     }
 }
@@ -373,15 +373,15 @@ fn atomic_swap1_finish(ctx: EscrowFinishContext) -> i32 {
         Err(e) => {
             // If the data field doesn't exist, this is Phase 1
             if e.code() == xrpl_common_stdlib::host::error_codes::FIELD_NOT_FOUND {
-                let _ = trace_num("No data field found - this is Phase 1", 0);
+                trace_num("No data field found - this is Phase 1", 0);
                 return phase1_initialize(current_escrow);
             }
-            let _ = trace_num("Error getting current escrow data:", e.code() as i64);
+            trace_num("Error getting current escrow data:", e.code() as i64);
             return e.code();
         }
     };
 
-    let _ = trace_num("Current data length:", current_data.len as i64);
+    trace_num("Current data length:", current_data.len as i64);
 
     // STATE MACHINE: Determine execution phase based on data field length
     // Phase 1: data.len == 0 (no state stored yet)

--- a/examples/smart-escrows/atomic_swap/atomic_swap1/src/lib.rs
+++ b/examples/smart-escrows/atomic_swap/atomic_swap1/src/lib.rs
@@ -6,7 +6,7 @@ extern crate std;
 use xrpl_common_stdlib::fields::locator::Locator;
 use xrpl_common_stdlib::host;
 use xrpl_common_stdlib::host::error_codes::match_result_code_with_expected_bytes;
-use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+use xrpl_common_stdlib::host::trace::{trace_hex, trace_num};
 use xrpl_common_stdlib::host::tx_inner;
 use xrpl_common_stdlib::host::{Error, Result, Result::Err, Result::Ok};
 use xrpl_common_stdlib::ledger_entry_ids::XRPL_LEDGER_ENTRY_ID_SIZE;
@@ -125,11 +125,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     // Extract the counterpart escrow ledger entry ID (first 32 bytes of memo)
     let counterpart_escrow_id: [u8; XRPL_LEDGER_ENTRY_ID_SIZE] =
         memo.data[0..32].try_into().unwrap();
-    trace_data(
-        "Counterpart escrow ID from memo:",
-        &counterpart_escrow_id,
-        DataRepr::AsHex,
-    );
+    trace_hex("Counterpart escrow ID from memo:", &counterpart_escrow_id);
 
     // Load the counterpart escrow from the ledger
     let counterpart_slot = unsafe {
@@ -174,10 +170,9 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
         return VALIDATION_FAILED;
     }
 
-    trace_data(
+    trace_hex(
         "Counterpart data field:",
         &counterpart_data.data[0..counterpart_data.len],
-        DataRepr::AsHex,
     );
 
     // Get current escrow's account and destination fields
@@ -219,26 +214,17 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
 
     // ATOMIC SWAP VALIDATION: Verify inverted account correlations
     if current_account.0 != counterpart_destination.0 {
-        trace_data("Current account:", &current_account.0, DataRepr::AsHex);
-        trace_data(
+        trace_hex("Current account:", &current_account.0);
+        trace_hex(
             "Expected counterpart destination:",
             &counterpart_destination.0,
-            DataRepr::AsHex,
         );
         return VALIDATION_FAILED;
     }
 
     if current_destination.0 != counterpart_account.0 {
-        trace_data(
-            "Current destination:",
-            &current_destination.0,
-            DataRepr::AsHex,
-        );
-        trace_data(
-            "Expected counterpart account:",
-            &counterpart_account.0,
-            DataRepr::AsHex,
-        );
+        trace_hex("Current destination:", &current_destination.0);
+        trace_hex("Expected counterpart account:", &counterpart_account.0);
         return VALIDATION_FAILED;
     }
 
@@ -271,11 +257,7 @@ fn phase1_initialize(current_escrow: &CurrentEscrow) -> i32 {
     new_data.len = LEDGER_ENTRY_ID_PLUS_TIMESTAMP_SIZE;
 
     trace_num("Updated data length:", new_data.len as i64);
-    trace_data(
-        "Updated data:",
-        &new_data.data[0..new_data.len],
-        DataRepr::AsHex,
-    );
+    trace_hex("Updated data:", &new_data.data[0..new_data.len]);
 
     // Persist the updated data field to the escrow object
     match <CurrentEscrow as CurrentEscrowFields>::update_current_escrow_data(new_data) {

--- a/examples/smart-escrows/atomic_swap/atomic_swap2/src/lib.rs
+++ b/examples/smart-escrows/atomic_swap/atomic_swap2/src/lib.rs
@@ -5,7 +5,7 @@ extern crate std;
 
 use xrpl_common_stdlib::host;
 use xrpl_common_stdlib::host::error_codes::match_result_code_with_expected_bytes;
-use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+use xrpl_common_stdlib::host::trace::{trace_hex, trace_num};
 use xrpl_common_stdlib::host::{Result::Err, Result::Ok};
 use xrpl_common_stdlib::ledger_entry_ids::XRPL_LEDGER_ENTRY_ID_SIZE;
 use xrpl_common_stdlib::objects::traits::EscrowFields;
@@ -95,11 +95,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
     };
 
     trace_num("Current data length:", current_data.len as i64);
-    trace_data(
-        "Current data:",
-        &current_data.data[0..current_data.len],
-        DataRepr::AsHex,
-    );
+    trace_hex("Current data:", &current_data.data[0..current_data.len]);
 
     // STATE MACHINE: Determine execution phase based on data field length
     // Phase 1: data.len <= 32 (contains only first escrow ledger entry ID)
@@ -119,11 +115,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         // Extract the first escrow ledger entry ID from data field
         let first_escrow_id: [u8; XRPL_LEDGER_ENTRY_ID_SIZE] =
             current_data.data[0..32].try_into().unwrap();
-        trace_data(
-            "First escrow ID from data:",
-            &first_escrow_id,
-            DataRepr::AsHex,
-        );
+        trace_hex("First escrow ID from data:", &first_escrow_id);
 
         // Verify the referenced first escrow exists on the ledger
         // This ensures we're referencing a valid counterpart for the atomic swap
@@ -205,12 +197,8 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
 
         // Verify proper account reversal: first(A→B) ↔ current(B→A)
         if first_account.0 != current_destination.0 {
-            trace_data("First escrow account:", &first_account.0, DataRepr::AsHex);
-            trace_data(
-                "Current escrow destination:",
-                &current_destination.0,
-                DataRepr::AsHex,
-            );
+            trace_hex("First escrow account:", &first_account.0);
+            trace_hex("Current escrow destination:", &current_destination.0);
             trace_num(
                 "Account reversal validation failed - accounts don't match",
                 0,
@@ -219,16 +207,8 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         }
 
         if first_destination.0 != current_account.0 {
-            trace_data(
-                "First escrow destination:",
-                &first_destination.0,
-                DataRepr::AsHex,
-            );
-            trace_data(
-                "Current escrow account:",
-                &current_account.0,
-                DataRepr::AsHex,
-            );
+            trace_hex("First escrow destination:", &first_destination.0);
+            trace_hex("Current escrow account:", &current_account.0);
             trace_num(
                 "Account reversal validation failed - destinations don't match",
                 0,
@@ -266,11 +246,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         current_data.len += 4;
 
         trace_num("Updated data length:", current_data.len as i64);
-        trace_data(
-            "Updated data:",
-            &current_data.data[0..current_data.len],
-            DataRepr::AsHex,
-        );
+        trace_hex("Updated data:", &current_data.data[0..current_data.len]);
 
         // Persist the updated data field to the escrow object
         match <CurrentEscrow as CurrentEscrowFields>::update_current_escrow_data(current_data) {

--- a/examples/smart-escrows/atomic_swap/atomic_swap2/src/lib.rs
+++ b/examples/smart-escrows/atomic_swap/atomic_swap2/src/lib.rs
@@ -89,13 +89,13 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
     let mut current_data = match current_escrow.get_data() {
         Ok(data) => data,
         Err(e) => {
-            let _ = trace_num("Error getting current escrow data:", e.code() as i64);
+            trace_num("Error getting current escrow data:", e.code() as i64);
             return e.code();
         }
     };
 
-    let _ = trace_num("Current data length:", current_data.len as i64);
-    let _ = trace_data(
+    trace_num("Current data length:", current_data.len as i64);
+    trace_data(
         "Current data:",
         &current_data.data[0..current_data.len],
         DataRepr::AsHex,
@@ -109,7 +109,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
 
         // Validate that the data contains exactly 32 bytes (first escrow ledger entry ID)
         if current_data.len != XRPL_LEDGER_ENTRY_ID_SIZE {
-            let _ = trace_num(
+            trace_num(
                 "Invalid data length for first run, expected 32 bytes, got:",
                 current_data.len as i64,
             );
@@ -119,7 +119,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         // Extract the first escrow ledger entry ID from data field
         let first_escrow_id: [u8; XRPL_LEDGER_ENTRY_ID_SIZE] =
             current_data.data[0..32].try_into().unwrap();
-        let _ = trace_data(
+        trace_data(
             "First escrow ID from data:",
             &first_escrow_id,
             DataRepr::AsHex,
@@ -130,7 +130,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         let first_escrow_slot =
             unsafe { host::cache_le(first_escrow_id.as_ptr(), first_escrow_id.len(), 0) };
         if first_escrow_slot < 0 {
-            let _ = trace_num(
+            trace_num(
                 "Failed to cache first escrow, error:",
                 first_escrow_slot as i64,
             );
@@ -140,7 +140,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         let first_escrow = Escrow::new(first_escrow_slot);
 
         // ENHANCED SECURITY VALIDATION: Verify first escrow properties
-        let _ = trace_num("Starting first escrow security validation", 0);
+        trace_num("Starting first escrow security validation", 0);
 
         // 1. WASM Validation: TEMPORARILY DISABLED
         // The Bytecode field can be larger than the 4KB buffer limit enforced by the host.
@@ -150,11 +150,11 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         let first_bytecode = match first_escrow.get_bytecode() {
             Ok(Some(wasm)) => wasm,
             Ok(None) => {
-                let _ = trace_num("First escrow has no Bytecode - security fail", 0);
+                trace_num("First escrow has no Bytecode - security fail", 0);
                 return VALIDATION_FAILED;
             }
             Err(e) => {
-                let _ = trace_num(
+                trace_num(
                     "Error getting first escrow Bytecode:",
                     e.code() as i64,
                 );
@@ -164,17 +164,17 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
 
         // Validate that the first escrow uses a compatible WASM contract
         if !is_valid_atomic_swap1_wasm(&first_bytecode.data[..first_bytecode.len]) {
-            let _ = trace_num("First escrow WASM validation failed - not atomic_swap1", 0);
+            trace_num("First escrow WASM validation failed - not atomic_swap1", 0);
             return VALIDATION_FAILED;
         }
-        let _ = trace_num("First escrow WASM validation passed", 0);
+        trace_num("First escrow WASM validation passed", 0);
         */
 
         // 2. Account Reversal Validation: Verify proper account setup between escrows
         let first_account = match first_escrow.account() {
             Ok(account) => account,
             Err(e) => {
-                let _ = trace_num("Error getting first escrow account:", e.code() as i64);
+                trace_num("Error getting first escrow account:", e.code() as i64);
                 return e.code();
             }
         };
@@ -182,7 +182,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         let first_destination = match first_escrow.destination() {
             Ok(destination) => destination,
             Err(e) => {
-                let _ = trace_num("Error getting first escrow destination:", e.code() as i64);
+                trace_num("Error getting first escrow destination:", e.code() as i64);
                 return e.code();
             }
         };
@@ -190,7 +190,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         let current_account = match current_escrow.get_account() {
             Ok(account) => account,
             Err(e) => {
-                let _ = trace_num("Error getting current escrow account:", e.code() as i64);
+                trace_num("Error getting current escrow account:", e.code() as i64);
                 return e.code();
             }
         };
@@ -198,20 +198,20 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         let current_destination = match current_escrow.get_destination() {
             Ok(destination) => destination,
             Err(e) => {
-                let _ = trace_num("Error getting current escrow destination:", e.code() as i64);
+                trace_num("Error getting current escrow destination:", e.code() as i64);
                 return e.code();
             }
         };
 
         // Verify proper account reversal: first(A→B) ↔ current(B→A)
         if first_account.0 != current_destination.0 {
-            let _ = trace_data("First escrow account:", &first_account.0, DataRepr::AsHex);
-            let _ = trace_data(
+            trace_data("First escrow account:", &first_account.0, DataRepr::AsHex);
+            trace_data(
                 "Current escrow destination:",
                 &current_destination.0,
                 DataRepr::AsHex,
             );
-            let _ = trace_num(
+            trace_num(
                 "Account reversal validation failed - accounts don't match",
                 0,
             );
@@ -219,45 +219,45 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         }
 
         if first_destination.0 != current_account.0 {
-            let _ = trace_data(
+            trace_data(
                 "First escrow destination:",
                 &first_destination.0,
                 DataRepr::AsHex,
             );
-            let _ = trace_data(
+            trace_data(
                 "Current escrow account:",
                 &current_account.0,
                 DataRepr::AsHex,
             );
-            let _ = trace_num(
+            trace_num(
                 "Account reversal validation failed - destinations don't match",
                 0,
             );
             return VALIDATION_FAILED;
         }
 
-        let _ = trace_num("All first escrow security validations passed", 0);
+        trace_num("All first escrow security validations passed", 0);
 
         // Get current escrow's CancelAfter field - this becomes our swap deadline
         let cancel_after = match current_escrow.get_cancel_after() {
             Ok(Some(cancel_after)) => cancel_after,
             Ok(None) => {
-                let _ = trace_num("Current escrow has no CancelAfter field", 0);
+                trace_num("Current escrow has no CancelAfter field", 0);
                 return VALIDATION_FAILED;
             }
             Err(e) => {
-                let _ = trace_num("Error getting CancelAfter:", e.code() as i64);
+                trace_num("Error getting CancelAfter:", e.code() as i64);
                 return e.code();
             }
         };
 
-        let _ = trace_num("Current escrow CancelAfter:", cancel_after as i64);
+        trace_num("Current escrow CancelAfter:", cancel_after as i64);
 
         // Append CancelAfter timestamp to data field (4 bytes, little-endian)
         // This stores the deadline for phase 2 validation
         let cancel_after_bytes = cancel_after.to_le_bytes();
         if current_data.len + 4 > XRPL_CONTRACT_DATA_SIZE {
-            let _ = trace_num("Data would exceed maximum size", 0);
+            trace_num("Data would exceed maximum size", 0);
             return VALIDATION_FAILED;
         }
 
@@ -265,8 +265,8 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
             .copy_from_slice(&cancel_after_bytes);
         current_data.len += 4;
 
-        let _ = trace_num("Updated data length:", current_data.len as i64);
-        let _ = trace_data(
+        trace_num("Updated data length:", current_data.len as i64);
+        trace_data(
             "Updated data:",
             &current_data.data[0..current_data.len],
             DataRepr::AsHex,
@@ -275,10 +275,10 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         // Persist the updated data field to the escrow object
         match <CurrentEscrow as CurrentEscrowFields>::update_current_escrow_data(current_data) {
             Ok(()) => {
-                let _ = trace_num("Successfully updated escrow data", 0);
+                trace_num("Successfully updated escrow data", 0);
             }
             Err(e) => {
-                let _ = trace_num("Error updating escrow data:", e.code() as i64);
+                trace_num("Error updating escrow data:", e.code() as i64);
                 return e.code();
             }
         }
@@ -290,7 +290,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
 
         // Validate data field contains at least 36 bytes (32 bytes ledger entry ID + 4 bytes timing)
         if current_data.len < LEDGER_ENTRY_ID_PLUS_TIMESTAMP_SIZE {
-            let _ = trace_num(
+            trace_num(
                 "Invalid data length for second run, expected at least 36 bytes, got:",
                 current_data.len as i64,
             );
@@ -309,7 +309,7 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
             .try_into()
             .unwrap();
         let cancel_after = u32::from_le_bytes(cancel_after_bytes);
-        let _ = trace_num("Extracted CancelAfter:", cancel_after as i64);
+        trace_num("Extracted CancelAfter:", cancel_after as i64);
 
         // Get current ledger time for deadline comparison
         let mut time_buffer = [0u8; 4];
@@ -321,21 +321,21 @@ fn atomic_swap2_finish(ctx: EscrowFinishContext) -> i32 {
         }) {
             Ok(time) => time,
             Err(e) => {
-                let _ = trace_num("Failed to get parent ledger time:", e.code() as i64);
+                trace_num("Failed to get parent ledger time:", e.code() as i64);
                 return VALIDATION_FAILED;
             }
         };
 
-        let _ = trace_num("Current ledger time:", current_time as i64);
+        trace_num("Current ledger time:", current_time as i64);
 
         // ATOMIC SWAP TIMING VALIDATION
         // Only allow completion if current time is before the deadline
         // This prevents stale swap attempts and enforces time-based coordination
         if current_time < cancel_after {
-            let _ = trace_num("Atomic swap executed before CancelAfter - success!", 0);
+            trace_num("Atomic swap executed before CancelAfter - success!", 0);
             1 // Success - escrow completes within deadline
         } else {
-            let _ = trace_num("Atomic swap attempted after CancelAfter - failed", 0);
+            trace_num("Atomic swap attempted after CancelAfter - failed", 0);
             0 // Failure - deadline exceeded, swap expired
         }
     }

--- a/examples/smart-escrows/freelancer_escrow/src/lib.rs
+++ b/examples/smart-escrows/freelancer_escrow/src/lib.rs
@@ -24,7 +24,7 @@ macro_rules! try_or_trace {
         match $e {
             Ok(v) => v,
             Err(e) => {
-                let _ = trace_num($label, e.code() as i64);
+                trace_num($label, e.code() as i64);
                 return e.code().into();
             }
         }

--- a/examples/smart-escrows/hello_world/src/lib.rs
+++ b/examples/smart-escrows/hello_world/src/lib.rs
@@ -9,6 +9,6 @@ use xrpl_macros::smart_escrow;
 
 #[smart_escrow]
 fn run(_ctx: EscrowFinishContext) -> FinishResult {
-    let _ = trace("Hello World");
+    trace("Hello World");
     FinishResult::succeed()
 }

--- a/examples/smart-escrows/kyc/src/lib.rs
+++ b/examples/smart-escrows/kyc/src/lib.rs
@@ -3,7 +3,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 extern crate std;
 
-use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+use xrpl_common_stdlib::host::trace::{trace_hex, trace_num};
 use xrpl_common_stdlib::host::{Result::Err, Result::Ok};
 use xrpl_common_stdlib::ledger_entry_ids::credential_id;
 use xrpl_escrow_stdlib::ledger_objects::traits::CurrentEscrowFields;
@@ -23,7 +23,7 @@ fn kyc_finish(ctx: EscrowFinishContext) -> FinishResult {
     let cred_type: &[u8] = b"termsandconditions";
     match credential_id(&account_id, &account_id, cred_type) {
         Ok(id) => {
-            trace_data("cred_id", &id, DataRepr::AsHex);
+            trace_hex("cred_id", &id);
 
             let slot = unsafe { xrpl_common_stdlib::host::cache_le(id.as_ptr(), id.len(), 0) };
             if slot < 0 {

--- a/examples/smart-escrows/kyc/src/lib.rs
+++ b/examples/smart-escrows/kyc/src/lib.rs
@@ -15,7 +15,7 @@ fn kyc_finish(ctx: EscrowFinishContext) -> FinishResult {
     let account_id = match ctx.escrow().get_destination() {
         Ok(account_id) => account_id,
         Err(e) => {
-            let _ = trace_num("Error getting destination", e.code() as i64);
+            trace_num("Error getting destination", e.code() as i64);
             return e.code().into(); // <-- Do not execute the escrow.
         }
     };
@@ -23,17 +23,17 @@ fn kyc_finish(ctx: EscrowFinishContext) -> FinishResult {
     let cred_type: &[u8] = b"termsandconditions";
     match credential_id(&account_id, &account_id, cred_type) {
         Ok(id) => {
-            let _ = trace_data("cred_id", &id, DataRepr::AsHex);
+            trace_data("cred_id", &id, DataRepr::AsHex);
 
             let slot = unsafe { xrpl_common_stdlib::host::cache_le(id.as_ptr(), id.len(), 0) };
             if slot < 0 {
-                let _ = trace_num("CACHE ERROR", i64::from(slot));
+                trace_num("CACHE ERROR", i64::from(slot));
                 return FinishResult::reject();
             };
             FinishResult::succeed() // <-- Finish the escrow to indicate a successful outcome
         }
         Err(e) => {
-            let _ = trace_num("Error getting credential ledger entry ID", e.code() as i64);
+            trace_num("Error getting credential ledger entry ID", e.code() as i64);
             e.code().into() // <-- Do not execute the escrow.
         }
     }

--- a/examples/smart-escrows/ledger_sqn/src/lib.rs
+++ b/examples/smart-escrows/ledger_sqn/src/lib.rs
@@ -22,7 +22,7 @@ fn check_ledger_sqn(_ctx: EscrowFinishContext) -> i32 {
         .unwrap();
 
         let ledger_sequence = u32::from_be_bytes(ledger_sqn_buffer);
-        let _ = trace_num("Ledger Sequence", ledger_sequence as i64);
+        trace_num("Ledger Sequence", ledger_sequence as i64);
         (ledger_sequence >= 5) as i32 // Return 1 if true (successful outcome), 0 if false (failed outcome)
     }
 }

--- a/examples/smart-escrows/nft_owner/src/lib.rs
+++ b/examples/smart-escrows/nft_owner/src/lib.rs
@@ -54,7 +54,7 @@ fn nft_owner_finish(ctx: EscrowFinishContext) -> FinishResult {
             }
         }
         Err(e) => {
-            let _ = trace_num("Error getting first memo:", e.code() as i64);
+            trace_num("Error getting first memo:", e.code() as i64);
             return e.code().into(); // <-- Do not execute the escrow.
         }
     };
@@ -62,41 +62,41 @@ fn nft_owner_finish(ctx: EscrowFinishContext) -> FinishResult {
     // Extract NFT ID from memo (first 32 bytes) and create NFToken
     let nft_id_bytes: [u8; NFT_ID_SIZE] = memo.data[0..32].try_into().unwrap();
     let nft_token = NFToken::new(nft_id_bytes);
-    let _ = trace_data("NFT ID from memo:", nft_token.as_bytes(), DataRepr::AsHex);
+    trace_data("NFT ID from memo:", nft_token.as_bytes(), DataRepr::AsHex);
 
     // Demonstrate NFToken field extraction
     if let Ok(nft_flags) = nft_token.flags() {
-        let _ = trace_num("NFT Flags:", nft_flags.as_u16() as i64);
+        trace_num("NFT Flags:", nft_flags.as_u16() as i64);
         if nft_flags.is_burnable() {
-            let _ = trace_num("  - BURNABLE:", 1);
+            trace_num("  - BURNABLE:", 1);
         }
         if nft_flags.is_only_xrp() {
-            let _ = trace_num("  - ONLY_XRP:", 1);
+            trace_num("  - ONLY_XRP:", 1);
         }
         if nft_flags.is_trust_line() {
-            let _ = trace_num("  - TRUST_LINE:", 1);
+            trace_num("  - TRUST_LINE:", 1);
         }
         if nft_flags.is_transferable() {
-            let _ = trace_num("  - TRANSFERABLE:", 1);
+            trace_num("  - TRANSFERABLE:", 1);
         }
     }
     if let Ok(transfer_fee) = nft_token.transfer_fee() {
-        let _ = trace_num("NFT Transfer Fee:", transfer_fee as i64);
+        trace_num("NFT Transfer Fee:", transfer_fee as i64);
     }
     if let Ok(issuer) = nft_token.issuer() {
-        let _ = trace_data("NFT Issuer:", &issuer.0, DataRepr::AsHex);
+        trace_data("NFT Issuer:", &issuer.0, DataRepr::AsHex);
     }
     if let Ok(taxon) = nft_token.taxon() {
-        let _ = trace_num("NFT Taxon:", taxon as i64);
+        trace_num("NFT Taxon:", taxon as i64);
     }
     if let Ok(token_sequence) = nft_token.token_sequence() {
-        let _ = trace_num("NFT Token Sequence:", token_sequence as i64);
+        trace_num("NFT Token Sequence:", token_sequence as i64);
     }
 
     let destination = match ctx.escrow().get_destination() {
         Ok(destination) => destination,
         Err(e) => {
-            let _ = trace_num("Error getting current ledger destination:", e.code() as i64);
+            trace_num("Error getting current ledger destination:", e.code() as i64);
             return e.code().into(); // <-- Do not execute the escrow.
         }
     };
@@ -104,11 +104,11 @@ fn nft_owner_finish(ctx: EscrowFinishContext) -> FinishResult {
     // Check if destination owns the NFT by attempting to retrieve its URI
     match nft_token.uri(&destination) {
         Ok(_uri) => {
-            let _ = trace_data("NFT is owned by destination", &[], DataRepr::AsHex);
+            trace_data("NFT is owned by destination", &[], DataRepr::AsHex);
             FinishResult::succeed() // <-- Finish the escrow successfully
         }
         Err(e) => {
-            let _ = trace_num(
+            trace_num(
                 "NFT is NOT owned by destination. Error code:",
                 e.code() as i64,
             );

--- a/examples/smart-escrows/nft_owner/src/lib.rs
+++ b/examples/smart-escrows/nft_owner/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate std;
 
 use xrpl_common_stdlib::fields::locator::Locator;
-use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+use xrpl_common_stdlib::host::trace::{trace_hex, trace_num};
 use xrpl_common_stdlib::host::tx_inner;
 use xrpl_common_stdlib::host::{Error, Result, Result::Err, Result::Ok};
 use xrpl_common_stdlib::sfield;
@@ -62,7 +62,7 @@ fn nft_owner_finish(ctx: EscrowFinishContext) -> FinishResult {
     // Extract NFT ID from memo (first 32 bytes) and create NFToken
     let nft_id_bytes: [u8; NFT_ID_SIZE] = memo.data[0..32].try_into().unwrap();
     let nft_token = NFToken::new(nft_id_bytes);
-    trace_data("NFT ID from memo:", nft_token.as_bytes(), DataRepr::AsHex);
+    trace_hex("NFT ID from memo:", nft_token.as_bytes());
 
     // Demonstrate NFToken field extraction
     if let Ok(nft_flags) = nft_token.flags() {
@@ -84,7 +84,7 @@ fn nft_owner_finish(ctx: EscrowFinishContext) -> FinishResult {
         trace_num("NFT Transfer Fee:", transfer_fee as i64);
     }
     if let Ok(issuer) = nft_token.issuer() {
-        trace_data("NFT Issuer:", &issuer.0, DataRepr::AsHex);
+        trace_hex("NFT Issuer:", &issuer.0);
     }
     if let Ok(taxon) = nft_token.taxon() {
         trace_num("NFT Taxon:", taxon as i64);
@@ -104,7 +104,7 @@ fn nft_owner_finish(ctx: EscrowFinishContext) -> FinishResult {
     // Check if destination owns the NFT by attempting to retrieve its URI
     match nft_token.uri(&destination) {
         Ok(_uri) => {
-            trace_data("NFT is owned by destination", &[], DataRepr::AsHex);
+            trace_hex("NFT is owned by destination", &[]);
             FinishResult::succeed() // <-- Finish the escrow successfully
         }
         Err(e) => {

--- a/examples/smart-escrows/notary/src/lib.rs
+++ b/examples/smart-escrows/notary/src/lib.rs
@@ -21,7 +21,7 @@ fn notary_finish(ctx: EscrowFinishContext) -> i32 {
     let tx_account = match ctx.tx().get_account() {
         Ok(v) => v,
         Err(e) => {
-            let _ = trace_num("Error in Notary contract", e.code() as i64);
+            trace_num("Error in Notary contract", e.code() as i64);
             return e.code(); // Must return to short circuit.
         }
     };

--- a/examples/smart-escrows/oracle/src/lib.rs
+++ b/examples/smart-escrows/oracle/src/lib.rs
@@ -26,16 +26,16 @@ pub fn get_price_from_oracle(slot: i32) -> Result<u64> {
     let series_len = match oracle.path().field(sfield::PriceDataSeries).array_len() {
         Ok(len) => len,
         Err(error) => {
-            let _ = trace_num("Error getting PriceDataSeries length", error.code() as i64);
+            trace_num("Error getting PriceDataSeries length", error.code() as i64);
             return Err(error);
         }
     };
-    let _ = trace_num(
+    trace_num(
         "get_price_from_oracle: price_data_series_len=",
         series_len as i64,
     );
     if series_len == 0 {
-        let _ = trace("get_price_from_oracle: oracle has no price data");
+        trace("get_price_from_oracle: oracle has no price data");
         return Err(Error::FieldNotFound);
     }
 
@@ -49,11 +49,11 @@ pub fn get_price_from_oracle(slot: i32) -> Result<u64> {
 
     match asset_price {
         Ok(price) => {
-            let _ = trace_num("get_price_from_oracle: asset_price=", price as i64);
+            trace_num("get_price_from_oracle: asset_price=", price as i64);
             Ok(price)
         }
         Err(error) => {
-            let _ = trace_num("Error getting asset_price", error.code() as i64);
+            trace_num("Error getting asset_price", error.code() as i64);
             Err(error) // Must return to short circuit.
         }
     }
@@ -64,7 +64,7 @@ fn oracle_finish(_ctx: EscrowFinishContext) -> FinishResult {
     let oracle_id = match oracle_id(&ORACLE_OWNER, ORACLE_DOCUMENT_ID) {
         Ok(id) => id,
         Err(error) => {
-            let _ = trace_num("finish: oracle_id error_code=", error.code() as i64);
+            trace_num("finish: oracle_id error_code=", error.code() as i64);
             return error.code().into();
         }
     };
@@ -72,10 +72,10 @@ fn oracle_finish(_ctx: EscrowFinishContext) -> FinishResult {
     let slot: i32;
     unsafe {
         slot = host::cache_le(oracle_id.as_ptr(), oracle_id.len(), 0);
-        let _ = trace_num("finish: cache_le slot=", slot as i64);
+        trace_num("finish: cache_le slot=", slot as i64);
 
         if slot < 0 {
-            let _ = trace_num("finish: cache_le failed, returning 0", 0);
+            trace_num("finish: cache_le failed, returning 0", 0);
             return FinishResult::reject();
         };
     }

--- a/skills/xrpl-smart-escrows/SKILL.md
+++ b/skills/xrpl-smart-escrows/SKILL.md
@@ -44,7 +44,7 @@ fn run(_ctx: EscrowFinishContext) -> FinishResult {
 - Execution must be deterministic — no wall-clock time, no randomness; use `parent_ldgr_time`/`ldgr_index` for time/sequence, not host-side clocks.
 - Compare token amounts via the `Amount`/`Number`/`IOUNumber` types (host-delegated decimal math), never raw floats.
 - Minimize host calls (`cache_le`, ledger entry ID computation, field reads) — cache results instead of repeating identical calls; `NoFreeSlots` and execution budget (`Gas`) are real limits.
-- Debug via `trace`/`trace_num`/`trace_data`/`trace_acct`/`trace_amt` — output lands in rippled's `debug.log`. Convention: on every error path, `trace_num("<context>", e.code() as i64)` before returning.
+- Debug via `trace`/`trace_num`/`trace_hex`/`trace_acct`/`trace_amt` — output lands in rippled's `debug.log`. Convention: on every error path, `trace_num("<context>", e.code() as i64)` before returning.
 
 ## Reference
 

--- a/skills/xrpl-smart-escrows/reference/api-surface.md
+++ b/skills/xrpl-smart-escrows/reference/api-surface.md
@@ -219,7 +219,8 @@ const B2: Blob<8> = blob!("DEADBEEF", 8);                                   // z
 
 ```rust
 pub fn trace(msg: &str) -> Result<i32>;
-pub fn trace_data(msg: &str, data: &[u8], data_repr: DataRepr) -> Result<i32>;  // DataRepr::AsUTF8 | AsHex
+pub fn trace_hex(msg: &str, data: &[u8]);   // host hex-encodes the bytes
+pub fn trace_text(msg: &str, data: &[u8]);  // host prints the bytes verbatim
 pub fn trace_num(msg: &str, number: i64) -> Result<i32>;
 pub fn trace_acct(msg: &str, account_id: &AccountID) -> Result<i32>;
 pub fn trace_amt(msg: &str, amount: &Amount) -> Result<i32>;

--- a/tools/compareHostFunctions.js
+++ b/tools/compareHostFunctions.js
@@ -129,6 +129,15 @@ async function main() {
     process.exit(1)
   }
 
+  // Fire-and-forget host functions (the trace family) have no return value. Rust spells that
+  // as either an omitted `->` or an explicit `-> ()`; C++ spells it `void`.
+  function translateReturnType(ret) {
+    if (ret === undefined || ret === "()") {
+      return "void"
+    }
+    return translateParamType(ret)
+  }
+
   function checkHits(fileTitle, rustHostFunctions) {
     console.log(`\n🔍 Comparing ${fileTitle} with C++ host functions...`)
     console.log(`   Found ${rustHostFunctions.length} Rust functions`)
@@ -205,7 +214,7 @@ async function main() {
 
     // Match multiline function declarations - need to match across newlines
     const regex =
-      /unsafe fn ([A-Za-z0-9_]+)\(\s*&self(?:,\s*([^)]*))?\s*\)\s*->\s*([A-Za-z0-9]+);/gm
+      /unsafe fn ([A-Za-z0-9_]+)\(\s*&self(?:,\s*([^)]*))?\s*\)\s*(?:->\s*([A-Za-z0-9]+|\(\)))?\s*;/gm
     let rustHits = [...rustHostFunctionFile.matchAll(regex)]
     console.log(
       `\n📝 host_bindings_trait.rs: Regex matched ${rustHits.length} functions`,
@@ -232,7 +241,7 @@ async function main() {
       .map((hit) => {
         return {
           name: hit[0],
-          return: translateParamType(hit[1]),
+          return: translateReturnType(hit[1]),
           params: hit[2].map(translateParamType),
         }
       })
@@ -249,7 +258,7 @@ async function main() {
 
     // Match multiline function declarations
     const regex =
-      /pub\(super\) fn ([A-Za-z0-9_]+)\(\s*([^)]*)\s*\)\s*->\s*([A-Za-z0-9]+);/gm
+      /pub\(super\) fn ([A-Za-z0-9_]+)\(\s*([^)]*)\s*\)\s*(?:->\s*([A-Za-z0-9]+|\(\)))?\s*;/gm
     let rustHits = [...rustHostfunctionFile.matchAll(regex)]
     console.log(
       `\n📝 host_bindings_wasm.rs: Regex matched ${rustHits.length} functions`,
@@ -274,7 +283,7 @@ async function main() {
       .map((hit) => {
         return {
           name: hit[0],
-          return: translateParamType(hit[1]),
+          return: translateReturnType(hit[1]),
           params: hit[2].map(translateParamType),
         }
       })
@@ -304,7 +313,7 @@ async function main() {
 
     // Match multiline function declarations (inside export_host_functions! macro)
     const regex =
-      /fn ([A-Za-z0-9_]+)\(\s*([^)]*)\s*\)\s*->\s*([A-Za-z0-9]+);?/gm
+      /fn ([A-Za-z0-9_]+)\(\s*([^)]*)\s*\)\s*(?:->\s*([A-Za-z0-9]+|\(\)))?\s*;/gm
     let rustTestHits = [...macroContent.matchAll(regex)]
     console.log(
       `\n📝 host_bindings_test.rs: Regex matched ${rustTestHits.length} functions`,
@@ -329,7 +338,7 @@ async function main() {
       .map((hit) => {
         return {
           name: hit[0],
-          return: translateParamType(hit[1]),
+          return: translateReturnType(hit[1]),
           params: hit[2].map(translateParamType),
         }
       })
@@ -359,8 +368,15 @@ async function main() {
 
     // Match multiline function declarations (inside export_host_functions! macro)
     const regex =
-      /fn ([A-Za-z0-9_]+)\(\s*([^)]*)\s*\)\s*->\s*([A-Za-z0-9]+);?/gm
-    let rustEmptyHits = [...macroContent.matchAll(regex)]
+      /fn ([A-Za-z0-9_]+)\(\s*([^)]*)\s*\)\s*(?:->\s*([A-Za-z0-9]+|\(\)))?\s*;/gm
+    // The unit-returning trace stubs can't go through the macro (it coerces the last parameter
+    // to i32 as the return value), so they're written out longhand after the invocation.
+    const longhandRegex =
+      /pub unsafe fn ([A-Za-z0-9_]+)\(\s*([^)]*?)\s*,?\s*\)\s*(?:->\s*([A-Za-z0-9]+|\(\)))?\s*\{/gm
+    let rustEmptyHits = [
+      ...macroContent.matchAll(regex),
+      ...rustHostFunctionFile.matchAll(longhandRegex),
+    ]
     console.log(
       `\n📝 host_bindings_empty.rs: Regex matched ${rustEmptyHits.length} functions`,
     )
@@ -379,7 +395,7 @@ async function main() {
       .map((hit) => {
         return {
           name: hit[0],
-          return: translateParamType(hit[1]),
+          return: translateReturnType(hit[1]),
           params: hit[2].map(translateParamType),
         }
       })

--- a/xrpl-common-stdlib/src/current_tx/traits.rs
+++ b/xrpl-common-stdlib/src/current_tx/traits.rs
@@ -376,7 +376,7 @@ mod tests {
             use crate::current_tx::traits::TransactionCommonFields;
             use crate::current_tx::traits::tests::TestTransaction;
             use crate::current_tx::traits::tests::expect_tx_field;
-            use crate::host::error_codes::{FIELD_NOT_FOUND, INTERNAL_ERROR, INVALID_FIELD};
+            use crate::host::error_codes::{FIELD_NOT_FOUND, INVALID_FIELD, SOME_ERROR};
             use crate::host::host_bindings_trait::MockHostBindings;
             use crate::host::setup_mock;
             use crate::sfield;
@@ -518,61 +518,61 @@ mod tests {
                 mock.expect_tx_field()
                     .with(eq(sfield::AccountTxnID), always(), eq(HASH256_SIZE))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_flags
                 mock.expect_tx_field()
                     .with(eq(sfield::Flags), always(), eq(4))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_last_ledger_sequence
                 mock.expect_tx_field()
                     .with(eq(sfield::LastLedgerSequence), always(), eq(4))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_network_id
                 mock.expect_tx_field()
                     .with(eq(sfield::NetworkID), always(), eq(4))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_source_tag
                 mock.expect_tx_field()
                     .with(eq(sfield::SourceTag), always(), eq(4))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_ticket_sequence
                 mock.expect_tx_field()
                     .with(eq(sfield::TicketSequence), always(), eq(4))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
 
                 let _guard = setup_mock(mock);
 
                 let tx = TestTransaction;
 
-                // Optional fields should return Err on INTERNAL_ERROR
+                // Optional fields should return Err on SOME_ERROR
                 let account_txn_id_result = tx.get_account_txn_id();
                 assert!(account_txn_id_result.is_err());
-                assert_eq!(account_txn_id_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(account_txn_id_result.err().unwrap().code(), SOME_ERROR);
 
                 let flags_result = tx.get_flags();
                 assert!(flags_result.is_err());
-                assert_eq!(flags_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(flags_result.err().unwrap().code(), SOME_ERROR);
 
                 let last_ledger_seq_result = tx.get_last_ledger_sequence();
                 assert!(last_ledger_seq_result.is_err());
-                assert_eq!(last_ledger_seq_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(last_ledger_seq_result.err().unwrap().code(), SOME_ERROR);
 
                 let network_id_result = tx.get_network_id();
                 assert!(network_id_result.is_err());
-                assert_eq!(network_id_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(network_id_result.err().unwrap().code(), SOME_ERROR);
 
                 let source_tag_result = tx.get_source_tag();
                 assert!(source_tag_result.is_err());
-                assert_eq!(source_tag_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(source_tag_result.err().unwrap().code(), SOME_ERROR);
 
                 let ticket_seq_result = tx.get_ticket_sequence();
                 assert!(ticket_seq_result.is_err());
-                assert_eq!(ticket_seq_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(ticket_seq_result.err().unwrap().code(), SOME_ERROR);
             }
 
             #[test]
@@ -645,7 +645,7 @@ mod tests {
             use crate::current_tx::traits::TransactionCommonFields;
             use crate::current_tx::traits::tests::TestTransaction;
             use crate::current_tx::traits::tests::expect_tx_field;
-            use crate::host::error_codes::{FIELD_NOT_FOUND, INTERNAL_ERROR, INVALID_FIELD};
+            use crate::host::error_codes::{FIELD_NOT_FOUND, INVALID_FIELD, SOME_ERROR};
             use crate::host::host_bindings_trait::MockHostBindings;
             use crate::host::setup_mock;
             use crate::sfield;
@@ -929,27 +929,27 @@ mod tests {
                 mock.expect_tx_field()
                     .with(eq(sfield::Account), always(), eq(ACCOUNT_ID_SIZE))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_transaction_type
                 mock.expect_tx_field()
                     .with(eq(sfield::TransactionType), always(), eq(2))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_gas
                 mock.expect_tx_field()
                     .with(eq(sfield::Gas), always(), eq(4))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_fee
                 mock.expect_tx_field()
                     .with(eq(sfield::Fee), always(), eq(AMOUNT_SIZE))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_sequence
                 mock.expect_tx_field()
                     .with(eq(sfield::Sequence), always(), eq(4))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_signing_pub_key
                 mock.expect_tx_field()
                     .with(
@@ -958,36 +958,36 @@ mod tests {
                         eq(PUBLIC_KEY_BUFFER_SIZE),
                     )
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
 
                 let _guard = setup_mock(mock);
 
                 let tx = TestTransaction;
 
-                // All mandatory fields should return Err on INTERNAL_ERROR
+                // All mandatory fields should return Err on SOME_ERROR
                 let account_result = tx.get_account();
                 assert!(account_result.is_err());
-                assert_eq!(account_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(account_result.err().unwrap().code(), SOME_ERROR);
 
                 let tx_type_result = tx.get_transaction_type();
                 assert!(tx_type_result.is_err());
-                assert_eq!(tx_type_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(tx_type_result.err().unwrap().code(), SOME_ERROR);
 
                 let comp_allow_result = tx.get_gas();
                 assert!(comp_allow_result.is_err());
-                assert_eq!(comp_allow_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(comp_allow_result.err().unwrap().code(), SOME_ERROR);
 
                 let fee_result = tx.get_fee();
                 assert!(fee_result.is_err());
-                assert_eq!(fee_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(fee_result.err().unwrap().code(), SOME_ERROR);
 
                 let seq_result = tx.get_sequence();
                 assert!(seq_result.is_err());
-                assert_eq!(seq_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(seq_result.err().unwrap().code(), SOME_ERROR);
 
                 let signing_key_result = tx.get_signing_pub_key();
                 assert!(signing_key_result.is_err());
-                assert_eq!(signing_key_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(signing_key_result.err().unwrap().code(), SOME_ERROR);
             }
 
             #[test]

--- a/xrpl-common-stdlib/src/fields/current_ledger_obj.rs
+++ b/xrpl-common-stdlib/src/fields/current_ledger_obj.rs
@@ -116,7 +116,7 @@ pub fn get_blob_field_optional<const N: usize, const CODE: i32>(
 #[cfg(test)]
 mod tests {
     use super::{get_blob_field, get_blob_field_optional, get_field, get_field_optional};
-    use crate::host::error_codes::{FIELD_NOT_FOUND, INTERNAL_ERROR};
+    use crate::host::error_codes::{FIELD_NOT_FOUND, SOME_ERROR};
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::host::setup_mock;
     use crate::sfield;
@@ -196,12 +196,12 @@ mod tests {
         mock.expect_home_le_field()
             .with(eq::<i32>(sfield::Flags.into()), always(), eq(4))
             .times(1)
-            .returning(|_, _, _| INTERNAL_ERROR);
+            .returning(|_, _, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = get_field::<u32, _>(sfield::Flags);
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]
@@ -270,12 +270,12 @@ mod tests {
         mock.expect_home_le_field()
             .with(eq::<i32>(sfield::Condition.into()), always(), eq(128))
             .times(1)
-            .returning(|_, _, _| INTERNAL_ERROR);
+            .returning(|_, _, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = get_blob_field(sfield::Condition);
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]

--- a/xrpl-common-stdlib/src/fields/current_tx.rs
+++ b/xrpl-common-stdlib/src/fields/current_tx.rs
@@ -160,7 +160,7 @@ pub fn get_blob_field_optional<const N: usize, const CODE: i32>(
 mod tests {
     use super::{get_blob_field, get_blob_field_optional, get_field, get_field_optional};
     use crate::fields::decoder::FieldDecoder;
-    use crate::host::error_codes::{FIELD_NOT_FOUND, INTERNAL_ERROR};
+    use crate::host::error_codes::{FIELD_NOT_FOUND, SOME_ERROR};
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::host::setup_mock;
     use crate::sfield;
@@ -250,12 +250,12 @@ mod tests {
         mock.expect_tx_field()
             .with(eq::<i32>(sfield::Flags.into()), always(), eq(4))
             .times(1)
-            .returning(|_, _, _| INTERNAL_ERROR);
+            .returning(|_, _, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = get_field::<u32, _>(sfield::Flags);
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]
@@ -342,12 +342,12 @@ mod tests {
         mock.expect_tx_field()
             .with(eq::<i32>(sfield::PublicKey.into()), always(), eq(33))
             .times(1)
-            .returning(|_, _, _| INTERNAL_ERROR);
+            .returning(|_, _, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = get_blob_field(sfield::PublicKey);
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]

--- a/xrpl-common-stdlib/src/fields/ledger_obj.rs
+++ b/xrpl-common-stdlib/src/fields/ledger_obj.rs
@@ -128,7 +128,7 @@ pub fn get_blob_field_optional<const N: usize, const CODE: i32>(
 #[cfg(test)]
 mod tests {
     use super::{get_blob_field, get_blob_field_optional, get_field, get_field_optional};
-    use crate::host::error_codes::{FIELD_NOT_FOUND, INTERNAL_ERROR};
+    use crate::host::error_codes::{FIELD_NOT_FOUND, SOME_ERROR};
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::host::setup_mock;
     use crate::sfield;
@@ -248,12 +248,12 @@ mod tests {
         mock.expect_le_field()
             .with(eq(SLOT), eq::<i32>(sfield::Flags.into()), always(), eq(4))
             .times(1)
-            .returning(|_, _, _, _| INTERNAL_ERROR);
+            .returning(|_, _, _, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = get_field::<u32, _>(SLOT, sfield::Flags);
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]
@@ -342,12 +342,12 @@ mod tests {
                 eq(128),
             )
             .times(1)
-            .returning(|_, _, _, _| INTERNAL_ERROR);
+            .returning(|_, _, _, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = get_blob_field(SLOT, sfield::Condition);
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]

--- a/xrpl-common-stdlib/src/fields/locator.rs
+++ b/xrpl-common-stdlib/src/fields/locator.rs
@@ -562,7 +562,7 @@ mod tests {
 
     // ---- Fluent path builder (`ctx.tx().path()`) ----
 
-    use crate::host::error_codes::FIELD_NOT_FOUND;
+    use crate::host::error_codes::{FIELD_NOT_FOUND, SOME_ERROR};
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::host::setup_mock;
     use mockall::predicate::{always, eq};
@@ -682,12 +682,11 @@ mod tests {
 
     #[test]
     fn test_get_propagates_host_error() {
-        use crate::host::error_codes::INTERNAL_ERROR;
         let mut mock = MockHostBindings::new();
         mock.expect_tx_inner()
             .with(always(), eq(4usize), always(), eq(4usize))
             .times(1)
-            .returning(|_, _, _, _| INTERNAL_ERROR);
+            .returning(|_, _, _, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = TxPathBuilder::for_current_tx()
@@ -695,7 +694,7 @@ mod tests {
             .get::<u32>();
 
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]
@@ -848,12 +847,11 @@ mod tests {
 
     #[test]
     fn test_ledger_get_propagates_host_error() {
-        use crate::host::error_codes::INTERNAL_ERROR;
         let mut mock = MockHostBindings::new();
         mock.expect_home_le_inner()
             .with(always(), eq(4usize), always(), eq(4usize))
             .times(1)
-            .returning(|_, _, _, _| INTERNAL_ERROR);
+            .returning(|_, _, _, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = LedgerPathBuilder::for_current_ledger_obj()
@@ -861,7 +859,7 @@ mod tests {
             .get::<u32>();
 
         assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]
@@ -979,18 +977,17 @@ mod tests {
 
     #[test]
     fn test_array_len_propagates_host_error() {
-        use crate::host::error_codes::INTERNAL_ERROR;
         let mut mock = MockHostBindings::new();
         mock.expect_home_le_inner_arr_len()
             .times(1)
-            .returning(|_, _| INTERNAL_ERROR);
+            .returning(|_, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         let result = LedgerPathBuilder::for_current_ledger_obj()
             .field(sfield::SignerEntries)
             .array_len();
 
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]

--- a/xrpl-common-stdlib/src/host/chain.rs
+++ b/xrpl-common-stdlib/src/host/chain.rs
@@ -40,7 +40,7 @@ pub fn amendment_enabled(hash: &[u8; 32]) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::host::error_codes::INTERNAL_ERROR;
+    use crate::host::error_codes::SOME_ERROR;
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::host::setup_mock;
 
@@ -82,7 +82,7 @@ mod tests {
         let mut mock = MockHostBindings::new();
         mock.expect_ldgr_index()
             .times(1)
-            .returning(|_, _| INTERNAL_ERROR);
+            .returning(|_, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         assert!(ledger_sqn().is_err());
@@ -109,7 +109,7 @@ mod tests {
         let mut mock = MockHostBindings::new();
         mock.expect_parent_ldgr_time()
             .times(1)
-            .returning(|_, _| INTERNAL_ERROR);
+            .returning(|_, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         assert!(parent_ledger_time().is_err());
@@ -136,7 +136,7 @@ mod tests {
         let mut mock = MockHostBindings::new();
         mock.expect_parent_ldgr_hash()
             .times(1)
-            .returning(|_, _| INTERNAL_ERROR);
+            .returning(|_, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         assert!(parent_ledger_hash().is_err());
@@ -161,9 +161,7 @@ mod tests {
     #[test]
     fn test_base_fee_error() {
         let mut mock = MockHostBindings::new();
-        mock.expect_base_fee()
-            .times(1)
-            .returning(|_, _| INTERNAL_ERROR);
+        mock.expect_base_fee().times(1).returning(|_, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         assert!(base_fee().is_err());
@@ -194,7 +192,7 @@ mod tests {
         let mut mock = MockHostBindings::new();
         mock.expect_amendment_enabled()
             .times(1)
-            .returning(|_, _| INTERNAL_ERROR);
+            .returning(|_, _| SOME_ERROR);
         let _guard = setup_mock(mock);
 
         assert!(amendment_enabled(&[0u8; 32]).is_err());

--- a/xrpl-common-stdlib/src/host/error_codes.rs
+++ b/xrpl-common-stdlib/src/host/error_codes.rs
@@ -2,8 +2,8 @@ use crate::host::Error::PointerOutOfBounds;
 use crate::host::trace::trace_num;
 use crate::host::{Error, Result, Result::Err, Result::Ok};
 
-/// Reserved for internal invariant trips, generally unrelated to inputs.
-pub const INTERNAL_ERROR: i32 = -1;
+/// The host function has an empty/stub implementation (not yet implemented by the host).
+pub const UNIMPLEMENTED: i32 = -1;
 /// The requested serialized field could not be found in the specified object.
 pub const FIELD_NOT_FOUND: i32 = -2;
 /// The provided buffer is too small to hold the requested data.
@@ -22,8 +22,8 @@ pub const SLOTS_FULL: i32 = -8;
 pub const EMPTY_SLOT: i32 = -9;
 /// The requested ledger object could not be found.
 pub const LEDGER_OBJ_NOT_FOUND: i32 = -10;
-/// An error occurred while decoding serialized data.
-pub const INVALID_DECODING: i32 = -11;
+/// The operation would exceed the allowed transfer limit.
+pub const OUT_OF_TRANSFER_LIMIT: i32 = -11;
 /// The data field is too large to be processed.
 pub const DATA_FIELD_TOO_LARGE: i32 = -12;
 /// A pointer or buffer length provided as a parameter described memory outside the allowed memory region.
@@ -42,6 +42,31 @@ pub const INDEX_OUT_OF_BOUNDS: i32 = -18;
 pub const INVALID_FLOAT_INPUT: i32 = -19;
 /// An error occurred during floating-point computation.
 pub const INVALID_FLOAT_COMPUTATION: i32 = -20;
+
+// ###################################################################################
+// Library-owned error codes (NOT part of the host ABI).
+//
+// The host only ever returns codes in the range above (or traps), so these live in a
+// range reserved for the stdlib, growing upward from `i32::MIN`. They describe
+// conditions the stdlib itself detected, not anything the host reported, so they can
+// never collide with a host code.
+//
+// `rippled` used to own two of these: `-1` meant an internal error (it now means
+// `Unimplemented`) and `-11` meant a decoding failure (it now means
+// `OutOfTransferLimit`). Both concepts are still needed here, so they moved down here
+// rather than being dropped.
+// ###################################################################################
+
+/// Reserved for internal invariant trips in the stdlib, generally unrelated to inputs.
+/// These indicate a bug and should be reported with an issue. Note that the invariant trips
+/// the stdlib can detect eagerly panic instead (see
+/// [`match_result_code_with_expected_bytes`]), so this is currently a reserved slot rather
+/// than one any library code returns.
+pub const INTERNAL_ERROR: i32 = i32::MIN;
+
+/// A byte slice the host returned could not be decoded into the requested type.
+/// Distinct from [`INTERNAL_ERROR`]: the invariant held, the bytes just didn't parse.
+pub const INVALID_DECODING: i32 = i32::MIN + 1;
 
 /// Evaluates a result code and executes a closure on success (result_code > 0).
 ///
@@ -208,16 +233,16 @@ where
         code if code == FIELD_NOT_FOUND => Ok(None),
         // Handle all positive, unexpected values as an internal error.
         code if code >= 0 => {
-            let _ = trace_num(
+            trace_num(
                 "Byte array was expected to have this many bytes: ",
                 expected_num_bytes as i64,
             );
-            let _ = trace_num("Byte array had this many bytes: ", code as i64);
+            trace_num("Byte array had this many bytes: ", code as i64);
             Err(PointerOutOfBounds)
         }
         // Handle all error values overtly.
         code => {
-            let _ = trace_num("Encountered error_code:", code as i64);
+            trace_num("Encountered error_code:", code as i64);
             Err(Error::from_code(code))
         }
     }
@@ -363,7 +388,7 @@ mod tests {
         // Set up expectations for trace_num calls (2 calls in the error path)
         mock.expect_trace_num()
             .with(always(), always(), always())
-            .returning(|_, _, _| 0)
+            .returning(|_, _, _| ())
             .times(2);
 
         let _guard = setup_mock(mock);
@@ -383,7 +408,7 @@ mod tests {
         // Set up expectations for trace_num call (1 call in the error path)
         mock.expect_trace_num()
             .with(always(), always(), always())
-            .returning(|_, _, _| 0);
+            .returning(|_, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -408,7 +433,7 @@ mod tests {
     #[test]
     fn test_all_error_constants_are_negative() {
         let error_codes = [
-            INTERNAL_ERROR,
+            UNIMPLEMENTED,
             FIELD_NOT_FOUND,
             BUFFER_TOO_SMALL,
             NO_ARRAY,
@@ -418,7 +443,7 @@ mod tests {
             SLOTS_FULL,
             EMPTY_SLOT,
             LEDGER_OBJ_NOT_FOUND,
-            INVALID_DECODING,
+            OUT_OF_TRANSFER_LIMIT,
             DATA_FIELD_TOO_LARGE,
             POINTER_OUT_OF_BOUNDS,
             NO_MEM_EXPORTED,
@@ -428,6 +453,8 @@ mod tests {
             INDEX_OUT_OF_BOUNDS,
             INVALID_FLOAT_INPUT,
             INVALID_FLOAT_COMPUTATION,
+            INTERNAL_ERROR,
+            INVALID_DECODING,
         ];
 
         for &code in &error_codes {
@@ -438,7 +465,7 @@ mod tests {
     #[test]
     fn test_error_constants_are_unique() {
         let error_codes = [
-            INTERNAL_ERROR,
+            UNIMPLEMENTED,
             FIELD_NOT_FOUND,
             BUFFER_TOO_SMALL,
             NO_ARRAY,
@@ -448,7 +475,7 @@ mod tests {
             SLOTS_FULL,
             EMPTY_SLOT,
             LEDGER_OBJ_NOT_FOUND,
-            INVALID_DECODING,
+            OUT_OF_TRANSFER_LIMIT,
             DATA_FIELD_TOO_LARGE,
             POINTER_OUT_OF_BOUNDS,
             NO_MEM_EXPORTED,
@@ -458,6 +485,8 @@ mod tests {
             INDEX_OUT_OF_BOUNDS,
             INVALID_FLOAT_INPUT,
             INVALID_FLOAT_COMPUTATION,
+            INTERNAL_ERROR,
+            INVALID_DECODING,
         ];
 
         // Check that all error codes are unique by comparing each pair
@@ -477,7 +506,7 @@ mod tests {
     #[test]
     fn test_error_from_code_roundtrip() {
         let test_codes = [
-            INTERNAL_ERROR,
+            UNIMPLEMENTED,
             FIELD_NOT_FOUND,
             BUFFER_TOO_SMALL,
             NO_ARRAY,
@@ -487,7 +516,7 @@ mod tests {
             SLOTS_FULL,
             EMPTY_SLOT,
             LEDGER_OBJ_NOT_FOUND,
-            INVALID_DECODING,
+            OUT_OF_TRANSFER_LIMIT,
             DATA_FIELD_TOO_LARGE,
             POINTER_OUT_OF_BOUNDS,
             NO_MEM_EXPORTED,
@@ -497,6 +526,8 @@ mod tests {
             INDEX_OUT_OF_BOUNDS,
             INVALID_FLOAT_INPUT,
             INVALID_FLOAT_COMPUTATION,
+            INTERNAL_ERROR,
+            INVALID_DECODING,
         ];
 
         for &code in &test_codes {

--- a/xrpl-common-stdlib/src/host/error_codes.rs
+++ b/xrpl-common-stdlib/src/host/error_codes.rs
@@ -43,29 +43,14 @@ pub const INVALID_FLOAT_INPUT: i32 = -19;
 /// An error occurred during floating-point computation.
 pub const INVALID_FLOAT_COMPUTATION: i32 = -20;
 
-// ###################################################################################
-// Library-owned error codes (NOT part of the host ABI).
-//
-// The host only ever returns codes in the range above (or traps), so these live in a
-// range reserved for the stdlib, growing upward from `i32::MIN`. They describe
-// conditions the stdlib itself detected, not anything the host reported, so they can
-// never collide with a host code.
-//
-// `rippled` used to own two of these: `-1` meant an internal error (it now means
-// `Unimplemented`) and `-11` meant a decoding failure (it now means
-// `OutOfTransferLimit`). Both concepts are still needed here, so they moved down here
-// rather than being dropped.
-// ###################################################################################
+// Library-owned error codes, reserved upward from `i32::MIN` so they can't collide with a host
+// code. xrpld reassigned `-1` and `-11`, so these two moved here rather than being dropped.
 
-/// Reserved for internal invariant trips in the stdlib, generally unrelated to inputs.
-/// These indicate a bug and should be reported with an issue. Note that the invariant trips
-/// the stdlib can detect eagerly panic instead (see
-/// [`match_result_code_with_expected_bytes`]), so this is currently a reserved slot rather
-/// than one any library code returns.
+/// Reserved for internal invariant trips. Currently a reserved slot: the trips the stdlib can
+/// detect eagerly panic instead (see [`match_result_code_with_expected_bytes`]).
 pub const INTERNAL_ERROR: i32 = i32::MIN;
 
 /// A byte slice the host returned could not be decoded into the requested type.
-/// Distinct from [`INTERNAL_ERROR`]: the invariant held, the bytes just didn't parse.
 pub const INVALID_DECODING: i32 = i32::MIN + 1;
 
 /// Evaluates a result code and executes a closure on success (result_code > 0).
@@ -385,10 +370,10 @@ mod tests {
     fn test_match_result_code_with_expected_bytes_optional_byte_mismatch() {
         let mut mock = MockHostBindings::new();
 
-        // Set up expectations for trace_num calls (2 calls in the error path)
-        mock.expect_trace_num()
-            .with(always(), always(), always())
-            .returning(|_, _, _| ())
+        // Two traces on the error path, both carrying an Int64 payload.
+        mock.expect_trace()
+            .with(always(), always(), always(), always(), always())
+            .returning(|_, _, _, _, _| ())
             .times(2);
 
         let _guard = setup_mock(mock);
@@ -405,10 +390,10 @@ mod tests {
     fn test_match_result_code_with_expected_bytes_optional_other_error() {
         let mut mock = MockHostBindings::new();
 
-        // Set up expectations for trace_num call (1 call in the error path)
-        mock.expect_trace_num()
-            .with(always(), always(), always())
-            .returning(|_, _, _| ());
+        // One trace on the error path, carrying an Int64 payload.
+        mock.expect_trace()
+            .with(always(), always(), always(), always(), always())
+            .returning(|_, _, _, _, _| ());
 
         let _guard = setup_mock(mock);
 

--- a/xrpl-common-stdlib/src/host/error_codes.rs
+++ b/xrpl-common-stdlib/src/host/error_codes.rs
@@ -44,14 +44,18 @@ pub const INVALID_FLOAT_INPUT: i32 = -19;
 pub const INVALID_FLOAT_COMPUTATION: i32 = -20;
 
 // Library-owned error codes, reserved upward from `i32::MIN` so they can't collide with a host
-// code. xrpld reassigned `-1` and `-11`, so these two moved here rather than being dropped.
-
-/// Reserved for internal invariant trips. Currently a reserved slot: the trips the stdlib can
-/// detect eagerly panic instead (see [`match_result_code_with_expected_bytes`]).
-pub const INTERNAL_ERROR: i32 = i32::MIN;
+// code.
 
 /// A byte slice the host returned could not be decoded into the requested type.
-pub const INVALID_DECODING: i32 = i32::MIN + 1;
+pub const INVALID_DECODING: i32 = i32::MIN;
+
+/// Stand-in for "the host returned some error", for tests that assert an error propagates rather
+/// than any particular code. The value is arbitrary; it only has to be a real host code the stdlib
+/// never constructs itself, so a passing test can't be explained by the code under test producing
+/// it independently. [`FIELD_NOT_FOUND`] cannot be used — the optional getters turn it into
+/// `Ok(None)`.
+#[cfg(any(test, feature = "test-host-bindings"))]
+pub const SOME_ERROR: i32 = NO_MEM_EXPORTED;
 
 /// Evaluates a result code and executes a closure on success (result_code > 0).
 ///
@@ -257,9 +261,8 @@ mod tests {
 
     #[test]
     fn test_match_result_code_error_negative() {
-        let result = match_result_code(INTERNAL_ERROR, || "should_not_execute");
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        let result = match_result_code(SOME_ERROR, || "should_not_execute");
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]
@@ -438,7 +441,6 @@ mod tests {
             INDEX_OUT_OF_BOUNDS,
             INVALID_FLOAT_INPUT,
             INVALID_FLOAT_COMPUTATION,
-            INTERNAL_ERROR,
             INVALID_DECODING,
         ];
 
@@ -470,7 +472,6 @@ mod tests {
             INDEX_OUT_OF_BOUNDS,
             INVALID_FLOAT_INPUT,
             INVALID_FLOAT_COMPUTATION,
-            INTERNAL_ERROR,
             INVALID_DECODING,
         ];
 
@@ -511,7 +512,6 @@ mod tests {
             INDEX_OUT_OF_BOUNDS,
             INVALID_FLOAT_INPUT,
             INVALID_FLOAT_COMPUTATION,
-            INTERNAL_ERROR,
             INVALID_DECODING,
         ];
 
@@ -544,7 +544,7 @@ mod tests {
             execution_count += 1;
             "should_not_execute"
         };
-        let _result = match_result_code(INTERNAL_ERROR, closure);
+        let _result = match_result_code(SOME_ERROR, closure);
         assert_eq!(execution_count, 0);
     }
 

--- a/xrpl-common-stdlib/src/host/host_bindings_empty.rs
+++ b/xrpl-common-stdlib/src/host/host_bindings_empty.rs
@@ -158,10 +158,18 @@ export_host_functions! {
     fn float_root(_in_buff: *const u8, _in_buff_len: usize, _root: i32, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
 
     // Host Function Category: TRACE
-    fn trace(_msg_read_ptr: *const u8, _msg_read_len: usize, _data_read_ptr: *const u8, _data_read_len: usize, _as_hex: i32) -> i32;
-    fn trace_num(_msg_read_ptr: *const u8, _msg_read_len: usize, _number: i64) -> i32;
-    fn trace_acct(_msg_read_ptr: *const u8, _msg_read_len: usize, _account_ptr: *const u8, _account_len: usize) -> i32;
-    fn trace_xfloat(_msg_read_ptr: *const u8, _msg_read_len: usize, _opaque_float_ptr: *const u8, _opaque_float_len: usize) -> i32;
-    fn trace_amt(_msg_read_ptr: *const u8, _msg_read_len: usize, _amount_ptr: *const u8, _amount_len: usize) -> i32;
-
 }
+
+// Host Function Category: TRACE
+// Fire-and-forget: these return nothing, so they can't go through the stub macro above
+// (it coerces the last parameter into an i32 return value).
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn trace(_msg_read_ptr: *const u8, _msg_read_len: usize, _data_read_ptr: *const u8, _data_read_len: usize, _as_hex: i32) {}
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn trace_num(_msg_read_ptr: *const u8, _msg_read_len: usize, _number: i64) {}
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn trace_acct(_msg_read_ptr: *const u8, _msg_read_len: usize, _account_ptr: *const u8, _account_len: usize) {}
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn trace_xfloat(_msg_read_ptr: *const u8, _msg_read_len: usize, _opaque_float_ptr: *const u8, _opaque_float_len: usize) {}
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn trace_amt(_msg_read_ptr: *const u8, _msg_read_len: usize, _amount_ptr: *const u8, _amount_len: usize) {}

--- a/xrpl-common-stdlib/src/host/host_bindings_empty.rs
+++ b/xrpl-common-stdlib/src/host/host_bindings_empty.rs
@@ -157,19 +157,16 @@ export_host_functions! {
     fn float_pow(_in_buff: *const u8, _in_buff_len: usize, _pow: i32, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
     fn float_root(_in_buff: *const u8, _in_buff_len: usize, _root: i32, _out_buff: *mut u8, _out_buff_len: usize, _rounding_mode: i32) -> i32;
 
-    // Host Function Category: TRACE
 }
 
 // Host Function Category: TRACE
-// Fire-and-forget: these return nothing, so they can't go through the stub macro above
-// (it coerces the last parameter into an i32 return value).
+// Returns nothing, so it can't go through the stub macro (which returns the last parameter).
 #[allow(clippy::missing_safety_doc)]
-pub unsafe fn trace(_msg_read_ptr: *const u8, _msg_read_len: usize, _data_read_ptr: *const u8, _data_read_len: usize, _as_hex: i32) {}
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn trace_num(_msg_read_ptr: *const u8, _msg_read_len: usize, _number: i64) {}
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn trace_acct(_msg_read_ptr: *const u8, _msg_read_len: usize, _account_ptr: *const u8, _account_len: usize) {}
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn trace_xfloat(_msg_read_ptr: *const u8, _msg_read_len: usize, _opaque_float_ptr: *const u8, _opaque_float_len: usize) {}
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn trace_amt(_msg_read_ptr: *const u8, _msg_read_len: usize, _amount_ptr: *const u8, _amount_len: usize) {}
+pub unsafe fn trace(
+    _msg_read_ptr: *const u8,
+    _msg_read_len: usize,
+    _data_type: i32,
+    _data_read_ptr: *const u8,
+    _data_read_len: usize,
+) {
+}

--- a/xrpl-common-stdlib/src/host/host_bindings_test.rs
+++ b/xrpl-common-stdlib/src/host/host_bindings_test.rs
@@ -189,12 +189,8 @@ pub fn apply_default_expectations(mock: &mut MockHostBindings) {
     mock.expect_float_root()
         .returning(|_, _, _, _, out_buff_len, _| out_buff_len as i32);
 
-    // Trace functions - fire-and-forget logging, return nothing
+    // Trace
     mock.expect_trace().returning(|_, _, _, _, _| ());
-    mock.expect_trace_num().returning(|_, _, _| ());
-    mock.expect_trace_acct().returning(|_, _, _, _| ());
-    mock.expect_trace_xfloat().returning(|_, _, _, _| ());
-    mock.expect_trace_amt().returning(|_, _, _, _| ());
 }
 
 // #[cfg(test)]
@@ -320,17 +316,14 @@ export_host_functions! {
     fn float_root(in_buff: *const u8, in_buff_len: usize, root: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
 
     // Host Function Category: TRACE
-    fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_read_ptr: *const u8, data_read_len: usize, as_hex: i32) -> ();
-    fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> ();
-    fn trace_acct(msg_read_ptr: *const u8, msg_read_len: usize, account_ptr: *const u8, account_len: usize) -> ();
-    fn trace_xfloat(msg_read_ptr: *const u8, msg_read_len: usize, opaque_float_ptr: *const u8, opaque_float_len: usize) -> ();
-    fn trace_amt(msg_read_ptr: *const u8, msg_read_len: usize, amount_ptr: *const u8, amount_len: usize) -> ();
+    fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_type: i32, data_read_ptr: *const u8, data_read_len: usize) -> ();
 
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::host::trace::TraceDataType;
 
     #[test]
     fn test_ledger_functions_with_mock() {
@@ -399,31 +392,30 @@ mod tests {
     fn test_trace_functions_with_mock() {
         let mut mock = MockHostBindings::new();
 
-        // Mock trace function (fire-and-forget, returns nothing)
         mock.expect_trace()
-            .times(1)
-            .returning(|_msg_ptr, _msg_len, _data_ptr, _data_len, _as_hex| ());
+            .times(2)
+            .returning(|_msg_ptr, _msg_len, _data_type, _data_ptr, _data_len| ());
 
-        // Mock trace_num function (fire-and-forget, returns nothing)
-        mock.expect_trace_num()
-            .times(1)
-            .returning(|_msg_ptr, _msg_len, _number| ());
-
-        // Test trace functions. Nothing is returned, so `.times(1)` on each expectation is
-        // what verifies the calls actually happened.
         let message = b"Test message";
         let data = b"Test data";
+        let number = 42i64.to_le_bytes();
 
         unsafe {
             mock.trace(
                 message.as_ptr(),
                 message.len(),
+                TraceDataType::AsText as i32,
                 data.as_ptr(),
                 data.len(),
-                0,
             );
 
-            mock.trace_num(message.as_ptr(), message.len(), 42);
+            mock.trace(
+                message.as_ptr(),
+                message.len(),
+                TraceDataType::Int64 as i32,
+                number.as_ptr(),
+                number.len(),
+            );
         }
     }
 

--- a/xrpl-common-stdlib/src/host/host_bindings_test.rs
+++ b/xrpl-common-stdlib/src/host/host_bindings_test.rs
@@ -189,22 +189,12 @@ pub fn apply_default_expectations(mock: &mut MockHostBindings) {
     mock.expect_float_root()
         .returning(|_, _, _, _, out_buff_len, _| out_buff_len as i32);
 
-    // Helper to calculate sum of two lengths, clamping to i32::MAX
-    let sum_lengths = |len1: usize, len2: usize| -> i32 {
-        len1.saturating_add(len2).min(i32::MAX as usize) as i32
-    };
-
-    // Trace functions - return sum of lengths (matching old host_bindings_for_testing.rs)
-    mock.expect_trace()
-        .returning(move |_, msg_len, _, data_len, _| sum_lengths(msg_len, data_len));
-    mock.expect_trace_num()
-        .returning(move |_, msg_len, _| sum_lengths(msg_len, 8));
-    mock.expect_trace_acct()
-        .returning(move |_, msg_len, _, acc_len| sum_lengths(msg_len, acc_len));
-    mock.expect_trace_xfloat()
-        .returning(move |_, msg_len, _, float_len| sum_lengths(msg_len, float_len));
-    mock.expect_trace_amt()
-        .returning(move |_, msg_len, _, amt_len| sum_lengths(msg_len, amt_len));
+    // Trace functions - fire-and-forget logging, return nothing
+    mock.expect_trace().returning(|_, _, _, _, _| ());
+    mock.expect_trace_num().returning(|_, _, _| ());
+    mock.expect_trace_acct().returning(|_, _, _, _| ());
+    mock.expect_trace_xfloat().returning(|_, _, _, _| ());
+    mock.expect_trace_amt().returning(|_, _, _, _| ());
 }
 
 // #[cfg(test)]
@@ -330,11 +320,11 @@ export_host_functions! {
     fn float_root(in_buff: *const u8, in_buff_len: usize, root: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
 
     // Host Function Category: TRACE
-    fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_read_ptr: *const u8, data_read_len: usize, as_hex: i32) -> i32;
-    fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> i32;
-    fn trace_acct(msg_read_ptr: *const u8, msg_read_len: usize, account_ptr: *const u8, account_len: usize) -> i32;
-    fn trace_xfloat(msg_read_ptr: *const u8, msg_read_len: usize, opaque_float_ptr: *const u8, opaque_float_len: usize) -> i32;
-    fn trace_amt(msg_read_ptr: *const u8, msg_read_len: usize, amount_ptr: *const u8, amount_len: usize) -> i32;
+    fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_read_ptr: *const u8, data_read_len: usize, as_hex: i32) -> ();
+    fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> ();
+    fn trace_acct(msg_read_ptr: *const u8, msg_read_len: usize, account_ptr: *const u8, account_len: usize) -> ();
+    fn trace_xfloat(msg_read_ptr: *const u8, msg_read_len: usize, opaque_float_ptr: *const u8, opaque_float_len: usize) -> ();
+    fn trace_amt(msg_read_ptr: *const u8, msg_read_len: usize, amount_ptr: *const u8, amount_len: usize) -> ();
 
 }
 
@@ -409,32 +399,31 @@ mod tests {
     fn test_trace_functions_with_mock() {
         let mut mock = MockHostBindings::new();
 
-        // Mock trace function
-        mock.expect_trace().times(1).returning(
-            |_msg_ptr, msg_len, _data_ptr, data_len, _as_hex| (msg_len + data_len) as i32,
-        );
+        // Mock trace function (fire-and-forget, returns nothing)
+        mock.expect_trace()
+            .times(1)
+            .returning(|_msg_ptr, _msg_len, _data_ptr, _data_len, _as_hex| ());
 
-        // Mock trace_num function
+        // Mock trace_num function (fire-and-forget, returns nothing)
         mock.expect_trace_num()
             .times(1)
-            .returning(|_msg_ptr, msg_len, _number| msg_len as i32);
+            .returning(|_msg_ptr, _msg_len, _number| ());
 
-        // Test trace functions
+        // Test trace functions. Nothing is returned, so `.times(1)` on each expectation is
+        // what verifies the calls actually happened.
         let message = b"Test message";
         let data = b"Test data";
 
         unsafe {
-            let result = mock.trace(
+            mock.trace(
                 message.as_ptr(),
                 message.len(),
                 data.as_ptr(),
                 data.len(),
                 0,
             );
-            assert_eq!(result, (message.len() + data.len()) as i32);
 
-            let result = mock.trace_num(message.as_ptr(), message.len(), 42);
-            assert_eq!(result, message.len() as i32);
+            mock.trace_num(message.as_ptr(), message.len(), 42);
         }
     }
 

--- a/xrpl-common-stdlib/src/host/host_bindings_trait.rs
+++ b/xrpl-common-stdlib/src/host/host_bindings_trait.rs
@@ -1515,12 +1515,8 @@ pub trait HostBindings {
     /// - `as_hex`: If 0 treat the data_read_ptr as pointing at a string of text, otherwise treat it
     ///   as data and print hex.
     ///
-    /// # Returns
-    ///
-    /// Returns an integer representing the result of the operation. A value of `0` or higher
-    /// signifies the number of message bytes that were written to the trace function. Non-zero
-    /// values indicate an error that corresponds to a known error code (e.g., incorrect buffer
-    /// sizes).
+    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
+    /// perspective.
     ///
     /// # Safety
     /// Caller must ensure all pointer parameters point to valid memory
@@ -1531,7 +1527,7 @@ pub trait HostBindings {
         data_read_ptr: *const u8,
         data_read_len: usize,
         as_hex: i32,
-    ) -> i32;
+    );
 
     /// Print a number to the trace log on XRPLd. Any XRPLd instance set to \"trace\" log level will
     /// see this.
@@ -1541,16 +1537,12 @@ pub trait HostBindings {
     /// * `msg_read_len`: The byte length of the text to send to the trace log.
     /// * `number`: Any integer you wish to display after the text.
     ///
-    /// # Returns
-    ///
-    /// Returns an integer representing the result of the operation. A value of `0` or higher
-    /// signifies the number of message bytes that were written to the trace function. Non-zero
-    /// values indicate an error that corresponds to a known error code (e.g., incorrect buffer
-    /// sizes).
+    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
+    /// perspective.
     ///
     /// # Safety
     /// Caller must ensure all pointer parameters point to valid memory
-    unsafe fn trace_num(&self, msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> i32;
+    unsafe fn trace_num(&self, msg_read_ptr: *const u8, msg_read_len: usize, number: i64);
 
     /// Print an account to the trace log on XRPLd. Any XRPLd instance set to \"trace\" log level will
     /// see this.
@@ -1561,12 +1553,8 @@ pub trait HostBindings {
     /// * `account_ptr`: A pointer to an account.
     /// * `account_len`: The byte length of the account.
     ///
-    /// # Returns
-    ///
-    /// Returns an integer representing the result of the operation. A value of `0` or higher
-    /// signifies the number of message bytes that were written to the trace function. Non-zero
-    /// values indicate an error that corresponds to a known error code (e.g., incorrect buffer
-    /// sizes).
+    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
+    /// perspective.
     ///
     /// # Safety
     /// Caller must ensure all pointer parameters point to valid memory
@@ -1576,7 +1564,7 @@ pub trait HostBindings {
         msg_read_len: usize,
         account_ptr: *const u8,
         account_len: usize,
-    ) -> i32;
+    );
 
     /// Print an OpaqueFloat number to the trace log on XRPLd. Any XRPLd instance set to \"trace\"
     /// log level will see this.
@@ -1587,12 +1575,8 @@ pub trait HostBindings {
     /// * `opaque_float_ptr`: A pointer to an array of 8 bytes containing the u64 opaque pointer value.
     /// * `opaque_float_len`: The byte length of the opaque float data.
     ///
-    /// # Returns
-    ///
-    /// Returns an integer representing the result of the operation. A value of `0` or higher
-    /// signifies the number of message bytes that were written to the trace function. Non-zero
-    /// values indicate an error that corresponds to a known error code (e.g., incorrect buffer
-    /// sizes).
+    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
+    /// perspective.
     ///
     /// # Safety
     /// Caller must ensure all pointer parameters point to valid memory
@@ -1602,7 +1586,7 @@ pub trait HostBindings {
         msg_read_len: usize,
         opaque_float_ptr: *const u8,
         opaque_float_len: usize,
-    ) -> i32;
+    );
 
     /// Print an amount to the trace log on XRPLd. Any XRPLd instance set to \"trace\" log level will
     /// see this.
@@ -1613,12 +1597,8 @@ pub trait HostBindings {
     /// * `amount_ptr`: A pointer to an amount.
     /// * `amount_len`: The byte length of the amount.
     ///
-    /// # Returns
-    ///
-    /// Returns an integer representing the result of the operation. A value of `0` or higher
-    /// signifies the number of message bytes that were written to the trace function. Non-zero
-    /// values indicate an error that corresponds to a known error code (e.g., incorrect buffer
-    /// sizes).
+    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
+    /// perspective.
     ///
     /// # Safety
     /// Caller must ensure all pointer parameters point to valid memory
@@ -1628,5 +1608,5 @@ pub trait HostBindings {
         msg_read_len: usize,
         amount_ptr: *const u8,
         amount_len: usize,
-    ) -> i32;
+    );
 }

--- a/xrpl-common-stdlib/src/host/host_bindings_trait.rs
+++ b/xrpl-common-stdlib/src/host/host_bindings_trait.rs
@@ -1508,15 +1508,15 @@ pub trait HostBindings {
     /// Print to the trace log on XRPLd. Any XRPLd instance set to \"trace\" log level will see this.
     ///
     /// # Parameters
-    /// - `msg_read_ptr`: A pointer to an array containing text characters (in either utf8).
+    /// - `msg_read_ptr`: A pointer to an array containing text characters (in utf8).
     /// - `msg_read_len`: The byte length of the text to send to the trace log.
-    /// - `data_read_ptr`: A pointer to an array of bytes containing arbitrary data.
-    /// - `data_read_len`: The byte length of the data to send to the trace log.
-    /// - `as_hex`: If 0 treat the data_read_ptr as pointing at a string of text, otherwise treat it
-    ///   as data and print hex.
+    /// - `data_type`: A [`crate::host::trace::TraceDataType`] discriminant selecting how the host
+    ///   reads the data buffer. Note that it sits between the message pair and the data pair.
+    /// - `data_read_ptr`: A pointer to an array of bytes containing the data to print.
+    /// - `data_read_len`: The byte length of that data. Numeric types require an exact width,
+    ///   little-endian.
     ///
-    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
-    /// perspective.
+    /// Fire-and-forget: returns nothing and cannot fail from the guest's perspective.
     ///
     /// # Safety
     /// Caller must ensure all pointer parameters point to valid memory
@@ -1524,89 +1524,8 @@ pub trait HostBindings {
         &self,
         msg_read_ptr: *const u8,
         msg_read_len: usize,
+        data_type: i32,
         data_read_ptr: *const u8,
         data_read_len: usize,
-        as_hex: i32,
-    );
-
-    /// Print a number to the trace log on XRPLd. Any XRPLd instance set to \"trace\" log level will
-    /// see this.
-    ///
-    /// # Parameters
-    /// * `msg_read_ptr`: A pointer to an array containing text characters (in either utf8).
-    /// * `msg_read_len`: The byte length of the text to send to the trace log.
-    /// * `number`: Any integer you wish to display after the text.
-    ///
-    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
-    /// perspective.
-    ///
-    /// # Safety
-    /// Caller must ensure all pointer parameters point to valid memory
-    unsafe fn trace_num(&self, msg_read_ptr: *const u8, msg_read_len: usize, number: i64);
-
-    /// Print an account to the trace log on XRPLd. Any XRPLd instance set to \"trace\" log level will
-    /// see this.
-    ///
-    /// # Parameters
-    /// * `msg_read_ptr`: A pointer to an array containing text characters (in either utf8).
-    /// * `msg_read_len`: The byte length of the text to send to the trace log.
-    /// * `account_ptr`: A pointer to an account.
-    /// * `account_len`: The byte length of the account.
-    ///
-    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
-    /// perspective.
-    ///
-    /// # Safety
-    /// Caller must ensure all pointer parameters point to valid memory
-    unsafe fn trace_acct(
-        &self,
-        msg_read_ptr: *const u8,
-        msg_read_len: usize,
-        account_ptr: *const u8,
-        account_len: usize,
-    );
-
-    /// Print an OpaqueFloat number to the trace log on XRPLd. Any XRPLd instance set to \"trace\"
-    /// log level will see this.
-    ///
-    /// # Parameters
-    /// * `msg_read_ptr`: A pointer to an array containing text characters (in either utf8).
-    /// * `msg_read_len`: The byte length of the text to send to the trace log.
-    /// * `opaque_float_ptr`: A pointer to an array of 8 bytes containing the u64 opaque pointer value.
-    /// * `opaque_float_len`: The byte length of the opaque float data.
-    ///
-    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
-    /// perspective.
-    ///
-    /// # Safety
-    /// Caller must ensure all pointer parameters point to valid memory
-    unsafe fn trace_xfloat(
-        &self,
-        msg_read_ptr: *const u8,
-        msg_read_len: usize,
-        opaque_float_ptr: *const u8,
-        opaque_float_len: usize,
-    );
-
-    /// Print an amount to the trace log on XRPLd. Any XRPLd instance set to \"trace\" log level will
-    /// see this.
-    ///
-    /// # Parameters
-    /// * `msg_read_ptr`: A pointer to an array containing text characters (in either utf8).
-    /// * `msg_read_len`: The byte length of the text to send to the trace log.
-    /// * `amount_ptr`: A pointer to an amount.
-    /// * `amount_len`: The byte length of the amount.
-    ///
-    /// Trace is fire-and-forget logging: it returns nothing and cannot fail from the guest's
-    /// perspective.
-    ///
-    /// # Safety
-    /// Caller must ensure all pointer parameters point to valid memory
-    unsafe fn trace_amt(
-        &self,
-        msg_read_ptr: *const u8,
-        msg_read_len: usize,
-        amount_ptr: *const u8,
-        amount_len: usize,
     );
 }

--- a/xrpl-common-stdlib/src/host/host_bindings_wasm.rs
+++ b/xrpl-common-stdlib/src/host/host_bindings_wasm.rs
@@ -360,28 +360,9 @@ mod host_defined_functions {
         pub(super) fn trace(
             msg_read_ptr: *const u8,
             msg_read_len: usize,
+            data_type: i32,
             data_read_ptr: *const u8,
             data_read_len: usize,
-            as_hex: i32,
-        );
-        pub(super) fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64);
-        pub(super) fn trace_acct(
-            msg_read_ptr: *const u8,
-            msg_read_len: usize,
-            account_ptr: *const u8,
-            account_len: usize,
-        );
-        pub(super) fn trace_xfloat(
-            msg_read_ptr: *const u8,
-            msg_read_len: usize,
-            opaque_float_ptr: *const u8,
-            opaque_float_len: usize,
-        );
-        pub(super) fn trace_amt(
-            msg_read_ptr: *const u8,
-            msg_read_len: usize,
-            amount_ptr: *const u8,
-            amount_len: usize,
         );
     }
 }
@@ -1277,63 +1258,18 @@ impl HostBindings for WasmHostBindings {
         &self,
         msg_read_ptr: *const u8,
         msg_read_len: usize,
+        data_type: i32,
         data_read_ptr: *const u8,
         data_read_len: usize,
-        as_hex: i32,
     ) {
         unsafe {
             host_defined_functions::trace(
                 msg_read_ptr,
                 msg_read_len,
+                data_type,
                 data_read_ptr,
                 data_read_len,
-                as_hex,
             )
-        }
-    }
-
-    unsafe fn trace_num(&self, msg_read_ptr: *const u8, msg_read_len: usize, number: i64) {
-        unsafe { host_defined_functions::trace_num(msg_read_ptr, msg_read_len, number) }
-    }
-
-    unsafe fn trace_acct(
-        &self,
-        msg_read_ptr: *const u8,
-        msg_read_len: usize,
-        account_ptr: *const u8,
-        account_len: usize,
-    ) {
-        unsafe {
-            host_defined_functions::trace_acct(msg_read_ptr, msg_read_len, account_ptr, account_len)
-        }
-    }
-
-    unsafe fn trace_xfloat(
-        &self,
-        msg_read_ptr: *const u8,
-        msg_read_len: usize,
-        opaque_float_ptr: *const u8,
-        opaque_float_len: usize,
-    ) {
-        unsafe {
-            host_defined_functions::trace_xfloat(
-                msg_read_ptr,
-                msg_read_len,
-                opaque_float_ptr,
-                opaque_float_len,
-            )
-        }
-    }
-
-    unsafe fn trace_amt(
-        &self,
-        msg_read_ptr: *const u8,
-        msg_read_len: usize,
-        amount_ptr: *const u8,
-        amount_len: usize,
-    ) {
-        unsafe {
-            host_defined_functions::trace_amt(msg_read_ptr, msg_read_len, amount_ptr, amount_len)
         }
     }
 }
@@ -1429,10 +1365,6 @@ export_host_functions! {
     fn float_root(in_buff: *const u8, in_buff_len: usize, root: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
 
     // Host Function Category: TRACE
-    fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_read_ptr: *const u8, data_read_len: usize, as_hex: i32) -> ();
-    fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> ();
-    fn trace_acct(msg_read_ptr: *const u8, msg_read_len: usize, account_ptr: *const u8, account_len: usize) -> ();
-    fn trace_xfloat(msg_read_ptr: *const u8, msg_read_len: usize, opaque_float_ptr: *const u8, opaque_float_len: usize) -> ();
-    fn trace_amt(msg_read_ptr: *const u8, msg_read_len: usize, amount_ptr: *const u8, amount_len: usize) -> ();
+    fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_type: i32, data_read_ptr: *const u8, data_read_len: usize) -> ();
 
 }

--- a/xrpl-common-stdlib/src/host/host_bindings_wasm.rs
+++ b/xrpl-common-stdlib/src/host/host_bindings_wasm.rs
@@ -363,26 +363,26 @@ mod host_defined_functions {
             data_read_ptr: *const u8,
             data_read_len: usize,
             as_hex: i32,
-        ) -> i32;
-        pub(super) fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> i32;
+        );
+        pub(super) fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64);
         pub(super) fn trace_acct(
             msg_read_ptr: *const u8,
             msg_read_len: usize,
             account_ptr: *const u8,
             account_len: usize,
-        ) -> i32;
+        );
         pub(super) fn trace_xfloat(
             msg_read_ptr: *const u8,
             msg_read_len: usize,
             opaque_float_ptr: *const u8,
             opaque_float_len: usize,
-        ) -> i32;
+        );
         pub(super) fn trace_amt(
             msg_read_ptr: *const u8,
             msg_read_len: usize,
             amount_ptr: *const u8,
             amount_len: usize,
-        ) -> i32;
+        );
     }
 }
 
@@ -1280,7 +1280,7 @@ impl HostBindings for WasmHostBindings {
         data_read_ptr: *const u8,
         data_read_len: usize,
         as_hex: i32,
-    ) -> i32 {
+    ) {
         unsafe {
             host_defined_functions::trace(
                 msg_read_ptr,
@@ -1292,7 +1292,7 @@ impl HostBindings for WasmHostBindings {
         }
     }
 
-    unsafe fn trace_num(&self, msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> i32 {
+    unsafe fn trace_num(&self, msg_read_ptr: *const u8, msg_read_len: usize, number: i64) {
         unsafe { host_defined_functions::trace_num(msg_read_ptr, msg_read_len, number) }
     }
 
@@ -1302,7 +1302,7 @@ impl HostBindings for WasmHostBindings {
         msg_read_len: usize,
         account_ptr: *const u8,
         account_len: usize,
-    ) -> i32 {
+    ) {
         unsafe {
             host_defined_functions::trace_acct(msg_read_ptr, msg_read_len, account_ptr, account_len)
         }
@@ -1314,7 +1314,7 @@ impl HostBindings for WasmHostBindings {
         msg_read_len: usize,
         opaque_float_ptr: *const u8,
         opaque_float_len: usize,
-    ) -> i32 {
+    ) {
         unsafe {
             host_defined_functions::trace_xfloat(
                 msg_read_ptr,
@@ -1331,7 +1331,7 @@ impl HostBindings for WasmHostBindings {
         msg_read_len: usize,
         amount_ptr: *const u8,
         amount_len: usize,
-    ) -> i32 {
+    ) {
         unsafe {
             host_defined_functions::trace_amt(msg_read_ptr, msg_read_len, amount_ptr, amount_len)
         }
@@ -1429,10 +1429,10 @@ export_host_functions! {
     fn float_root(in_buff: *const u8, in_buff_len: usize, root: i32, out_buff: *mut u8, out_buff_len: usize, rounding_mode: i32) -> i32;
 
     // Host Function Category: TRACE
-    fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_read_ptr: *const u8, data_read_len: usize, as_hex: i32) -> i32;
-    fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> i32;
-    fn trace_acct(msg_read_ptr: *const u8, msg_read_len: usize, account_ptr: *const u8, account_len: usize) -> i32;
-    fn trace_xfloat(msg_read_ptr: *const u8, msg_read_len: usize, opaque_float_ptr: *const u8, opaque_float_len: usize) -> i32;
-    fn trace_amt(msg_read_ptr: *const u8, msg_read_len: usize, amount_ptr: *const u8, amount_len: usize) -> i32;
+    fn trace(msg_read_ptr: *const u8, msg_read_len: usize, data_read_ptr: *const u8, data_read_len: usize, as_hex: i32) -> ();
+    fn trace_num(msg_read_ptr: *const u8, msg_read_len: usize, number: i64) -> ();
+    fn trace_acct(msg_read_ptr: *const u8, msg_read_len: usize, account_ptr: *const u8, account_len: usize) -> ();
+    fn trace_xfloat(msg_read_ptr: *const u8, msg_read_len: usize, opaque_float_ptr: *const u8, opaque_float_len: usize) -> ();
+    fn trace_amt(msg_read_ptr: *const u8, msg_read_len: usize, amount_ptr: *const u8, amount_len: usize) -> ();
 
 }

--- a/xrpl-common-stdlib/src/host/mod.rs
+++ b/xrpl-common-stdlib/src/host/mod.rs
@@ -131,7 +131,7 @@ impl<T> Result<T> {
             Result::Err(error) => {
                 #[cfg(target_arch = "wasm32")]
                 {
-                    let _ = trace::trace_num("error_code=", error.code() as i64);
+                    trace::trace_num("error_code=", error.code() as i64);
                 }
                 #[cfg(not(target_arch = "wasm32"))]
                 {
@@ -177,7 +177,7 @@ impl<T> Result<T> {
             let location = core::panic::Location::caller();
             #[cfg(target_arch = "wasm32")]
             {
-                let _ = trace::trace_num("error_code=", error.code() as i64);
+                trace::trace_num("error_code=", error.code() as i64);
             }
             #[cfg(not(target_arch = "wasm32"))]
             {
@@ -227,9 +227,8 @@ impl From<i64> for Result<u64> {
 #[derive(Clone, Copy, Debug)]
 #[repr(i32)]
 pub enum Error {
-    /// Reserved for internal invariant trips, generally unrelated to inputs.
-    /// These should be reported with an issue.
-    InternalError = error_codes::INTERNAL_ERROR,
+    /// The host function has an empty/stub implementation (not yet implemented by the host).
+    Unimplemented = error_codes::UNIMPLEMENTED,
 
     /// The requested serialized field could not be found in the specified object.
     /// This error is returned when attempting to access a field that doesn't exist
@@ -269,9 +268,8 @@ pub enum Error {
     /// This may occur if the object doesn't exist or the ledger entry ID is invalid.
     LedgerObjNotFound = error_codes::LEDGER_OBJ_NOT_FOUND,
 
-    /// An error occurred while decoding serialized data.
-    /// This typically indicates corrupted or invalidly formatted data.
-    InvalidDecoding = error_codes::INVALID_DECODING,
+    /// The operation would exceed the allowed transfer limit.
+    OutOfTransferLimit = error_codes::OUT_OF_TRANSFER_LIMIT,
 
     /// The data field is too large to be processed.
     /// Consider reducing the size of the data or splitting it into smaller chunks.
@@ -308,6 +306,19 @@ pub enum Error {
     /// An error occurred during floating-point computation.
     /// This may indicate overflow, underflow, or other arithmetic errors.
     InvalidFloatComputation = error_codes::INVALID_FLOAT_COMPUTATION,
+
+    /// Reserved for internal invariant trips in the stdlib, generally unrelated to inputs.
+    /// This is NOT a host ABI code: it would be produced by the stdlib itself on detecting a
+    /// bug. The invariant trips the stdlib detects eagerly panic instead, so this is currently
+    /// a reserved slot rather than one any library code returns. Should be reported as an issue
+    /// if it ever surfaces.
+    InternalError = error_codes::INTERNAL_ERROR,
+
+    /// A byte slice the host returned could not be decoded into the requested type.
+    /// This is NOT a host ABI code either: the host reported success, and the stdlib's own
+    /// decoder rejected the bytes. Distinct from [`Error::InternalError`] — no invariant was
+    /// violated, the data just didn't parse.
+    InvalidDecoding = error_codes::INVALID_DECODING,
 }
 
 impl Error {

--- a/xrpl-common-stdlib/src/host/mod.rs
+++ b/xrpl-common-stdlib/src/host/mod.rs
@@ -307,17 +307,9 @@ pub enum Error {
     /// This may indicate overflow, underflow, or other arithmetic errors.
     InvalidFloatComputation = error_codes::INVALID_FLOAT_COMPUTATION,
 
-    /// Reserved for internal invariant trips in the stdlib, generally unrelated to inputs.
-    /// This is NOT a host ABI code: it would be produced by the stdlib itself on detecting a
-    /// bug. The invariant trips the stdlib detects eagerly panic instead, so this is currently
-    /// a reserved slot rather than one any library code returns. Should be reported as an issue
-    /// if it ever surfaces.
-    InternalError = error_codes::INTERNAL_ERROR,
-
     /// A byte slice the host returned could not be decoded into the requested type.
-    /// This is NOT a host ABI code either: the host reported success, and the stdlib's own
-    /// decoder rejected the bytes. Distinct from [`Error::InternalError`] — no invariant was
-    /// violated, the data just didn't parse.
+    /// This is NOT a host ABI code: the host reported success, and the stdlib's own decoder
+    /// rejected the bytes.
     InvalidDecoding = error_codes::INVALID_DECODING,
 }
 

--- a/xrpl-common-stdlib/src/host/trace.rs
+++ b/xrpl-common-stdlib/src/host/trace.rs
@@ -1,40 +1,39 @@
-
 use crate::host;
 use crate::types::account_id::AccountID;
 use crate::types::amount::Amount;
 
-/// Data representation
+/// How the host should read the data buffer. Mirrors xrpld's `TraceDataType`; the discriminants
+/// are wire values, numbered from 1 so a zeroed `data_type` hits the host's invalid branch.
 #[derive(Clone, Copy)]
-pub enum DataRepr {
-    /// As UTF-8
-    AsUTF8 = 0,
-    /// As hexadecimal
-    AsHex = 1,
+#[repr(i32)]
+pub enum TraceDataType {
+    /// 8 little-endian bytes, printed as a signed decimal.
+    Int64 = 1,
+    /// 8 little-endian bytes, printed as an unsigned decimal.
+    Uint64 = 2,
+    /// 8 bytes holding an opaque float.
+    Xfloat = 3,
+    /// A 20-byte account ID, printed as base58.
+    Account = 4,
+    /// A serialized `STAmount`.
+    Amount = 5,
+    /// Raw bytes, hex-encoded by the host.
+    AsHex = 6,
+    /// Bytes printed verbatim as text.
+    AsText = 7,
 }
 
-/// Write the contents of a message to the xrpld trace log.
-///
-/// # Parameters
-/// * `msg`: A str ref pointing to an array of bytes containing UTF-8 characters.
-///
-/// # Returns
-///
-/// Returns an integer representing the result of the operation. A value of `0` or higher signifies
-/// the number of message bytes that were written to the trace function. Non-zero values indicate
-/// an error (e.g., incorrect buffer sizes).
-#[inline(always)] // <-- Inline because this function is very small
-pub fn trace(msg: &str) {
-    // Use an empty slice's pointer instead of null to satisfy Rust's safety requirements
-    // Even for zero-length slices, `slice::from_raw_parts` requires a non-null, aligned pointer
-    let empty_data: &[u8] = &[];
-
+/// Fire-and-forget: the host checks its log level, swallows every error, and drops the call
+/// silently when `msg.len() + data.len()` exceeds 1024 bytes.
+#[inline(always)]
+fn trace_impl(msg: &str, data_type: TraceDataType, data: &[u8]) {
     unsafe {
         host::trace(
             msg.as_ptr(),
             msg.len(),
-            empty_data.as_ptr(),
-            0usize,
-            DataRepr::AsUTF8 as _,
+            data_type as i32,
+            data.as_ptr(),
+            data.len(),
         )
     }
 }
@@ -43,19 +42,29 @@ pub fn trace(msg: &str) {
 ///
 /// # Parameters
 /// * `msg`: A str ref pointing to an array of bytes containing UTF-8 characters.
-///
-/// # Returns
-///
-/// Returns an integer representing the result of the operation. A value of `0` or higher signifies
-/// the number of message bytes that were written to the trace function. Non-zero values indicate
-/// an error (e.g., incorrect buffer sizes).
 #[inline(always)] // <-- Inline because this function is very small
-pub fn trace_data(msg: &str, data: &[u8], data_repr: DataRepr) {
-    unsafe {
-        let data_ptr = data.as_ptr();
-        let data_len = data.len();
-        host::trace(msg.as_ptr(), msg.len(), data_ptr, data_len, data_repr as _)
-    };
+pub fn trace(msg: &str) {
+    trace_impl(msg, TraceDataType::AsText, &[]);
+}
+
+/// Write a message and a data buffer to the xrpld trace log, hex-encoded by the host.
+///
+/// # Parameters
+/// * `msg`: A str ref pointing to an array of bytes containing UTF-8 characters.
+/// * `data`: The bytes to emit alongside `msg`.
+#[inline(always)] // <-- Inline because this function is very small
+pub fn trace_hex(msg: &str, data: &[u8]) {
+    trace_impl(msg, TraceDataType::AsHex, data);
+}
+
+/// Write a message and a data buffer to the xrpld trace log, printed verbatim as text.
+///
+/// # Parameters
+/// * `msg`: A str ref pointing to an array of bytes containing UTF-8 characters.
+/// * `data`: The bytes to emit alongside `msg`.
+#[inline(always)] // <-- Inline because this function is very small
+pub fn trace_text(msg: &str, data: &[u8]) {
+    trace_impl(msg, TraceDataType::AsText, data);
 }
 
 /// Write the contents of a message, and a number, to the xrpld trace log.
@@ -63,53 +72,43 @@ pub fn trace_data(msg: &str, data: &[u8], data_repr: DataRepr) {
 /// # Parameters
 /// * `msg`: A str ref pointing to an array of bytes containing UTF-8 characters.
 /// * `number`: A number to emit into the trace logs.
-///
-/// # Returns
-///
-/// Returns an integer representing the result of the operation. A value of `0` or higher signifies
-/// the number of message bytes that were written to the trace function. Non-zero values indicate
-/// an error (e.g., incorrect buffer sizes).
 #[inline(always)]
 pub fn trace_num(msg: &str, number: i64) {
-    unsafe { host::trace_num(msg.as_ptr(), msg.len(), number) };
+    trace_impl(msg, TraceDataType::Int64, &number.to_le_bytes());
+}
+
+/// Write the contents of a message, and an unsigned number, to the xrpld trace log. Use this
+/// over [`trace_num`] for values above [`i64::MAX`].
+///
+/// # Parameters
+/// * `msg`: A str ref pointing to an array of bytes containing UTF-8 characters.
+/// * `number`: A number to emit into the trace logs.
+#[inline(always)]
+pub fn trace_num_unsigned(msg: &str, number: u64) {
+    trace_impl(msg, TraceDataType::Uint64, &number.to_le_bytes());
 }
 
 #[inline(always)]
 pub fn trace_acct_buf(msg: &str, account_id: &[u8; 20]) {
-    unsafe {
-        host::trace_acct(
-            msg.as_ptr(),
-            msg.len(),
-            account_id.as_ptr(),
-            account_id.len(),
-        )
-    }
+    trace_impl(msg, TraceDataType::Account, account_id);
 }
 
 #[inline(always)]
 pub fn trace_acct(msg: &str, account_id: &AccountID) {
-    unsafe {
-        host::trace_acct(
-            msg.as_ptr(),
-            msg.len(),
-            account_id.0.as_ptr(),
-            account_id.0.len(),
-        )
-    }
+    trace_impl(msg, TraceDataType::Account, &account_id.0);
 }
 
 #[inline(always)]
 pub fn trace_amt(msg: &str, amount: &Amount) {
-    // Convert Amount to the STAmount format expected by the host trace function
     let (amount_bytes, len) = amount.to_stamount_bytes();
 
-    unsafe { host::trace_amt(msg.as_ptr(), msg.len(), amount_bytes.as_ptr(), len) };
+    trace_impl(msg, TraceDataType::Amount, &amount_bytes[..len]);
 }
 
-/// Write a float to the XRPLD trace log
+/// Write a float to the xrpld trace log.
 #[inline(always)]
 pub fn trace_float(msg: &str, f: &[u8; 8]) {
-    unsafe { host::trace_xfloat(msg.as_ptr(), msg.len(), f.as_ptr(), 8) };
+    trace_impl(msg, TraceDataType::Xfloat, f);
 }
 
 #[cfg(test)]
@@ -118,7 +117,6 @@ mod tests {
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::host::setup_mock;
     use crate::types::amount::Amount;
-    use mockall::predicate::always;
 
     #[test]
     fn test_trace_amt_xrp() {
@@ -126,10 +124,10 @@ mod tests {
 
         let message = "Test XRP amount";
 
-        // Set up expectations for trace_amt call
-        mock.expect_trace_amt()
-            .with(always(), always(), always(), always())
-            .returning(|_, _, _, _| ());
+        mock.expect_trace()
+            .withf(|_, _, data_type, _, _| *data_type == TraceDataType::Amount as i32)
+            .times(1)
+            .returning(|_, _, _, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -138,8 +136,6 @@ mod tests {
             num_drops: 1_000_000,
         };
 
-        // Smoke test only: trace is fire-and-forget, and the mock matches any arguments, so
-        // there is nothing to assert beyond the call not panicking.
         trace_amt(message, &amount);
     }
 
@@ -149,10 +145,10 @@ mod tests {
 
         let message = "Test MPT amount";
 
-        // Set up expectations for trace_amt call
-        mock.expect_trace_amt()
-            .with(always(), always(), always(), always())
-            .returning(|_, _, _, _| ());
+        mock.expect_trace()
+            .withf(|_, _, data_type, _, _| *data_type == TraceDataType::Amount as i32)
+            .times(1)
+            .returning(|_, _, _, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -172,8 +168,6 @@ mod tests {
             mpt_id,
         };
 
-        // Smoke test only: trace is fire-and-forget, and the mock matches any arguments, so
-        // there is nothing to assert beyond the call not panicking.
         trace_amt(message, &amount);
     }
 
@@ -183,10 +177,10 @@ mod tests {
 
         let message = "Test IOU amount";
 
-        // Set up expectations for trace_amt call
-        mock.expect_trace_amt()
-            .with(always(), always(), always(), always())
-            .returning(|_, _, _, _| ());
+        mock.expect_trace()
+            .withf(|_, _, data_type, _, _| *data_type == TraceDataType::Amount as i32)
+            .times(1)
+            .returning(|_, _, _, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -209,8 +203,6 @@ mod tests {
             currency,
         };
 
-        // Smoke test only: trace is fire-and-forget, and the mock matches any arguments, so
-        // there is nothing to assert beyond the call not panicking.
         trace_amt(message, &amount);
     }
 
@@ -220,10 +212,10 @@ mod tests {
 
         let message = "Test negative XRP amount";
 
-        // Set up expectations for trace_amt call
-        mock.expect_trace_amt()
-            .with(always(), always(), always(), always())
-            .returning(|_, _, _, _| ());
+        mock.expect_trace()
+            .withf(|_, _, data_type, _, _| *data_type == TraceDataType::Amount as i32)
+            .times(1)
+            .returning(|_, _, _, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -232,8 +224,6 @@ mod tests {
             num_drops: -1_000_000,
         };
 
-        // Smoke test only: trace is fire-and-forget, and the mock matches any arguments, so
-        // there is nothing to assert beyond the call not panicking.
         trace_amt(message, &amount);
     }
 

--- a/xrpl-common-stdlib/src/host/trace.rs
+++ b/xrpl-common-stdlib/src/host/trace.rs
@@ -1,7 +1,5 @@
-use crate::host::error_codes::match_result_code;
 
 use crate::host;
-use crate::host::Result;
 use crate::types::account_id::AccountID;
 use crate::types::amount::Amount;
 
@@ -25,12 +23,12 @@ pub enum DataRepr {
 /// the number of message bytes that were written to the trace function. Non-zero values indicate
 /// an error (e.g., incorrect buffer sizes).
 #[inline(always)] // <-- Inline because this function is very small
-pub fn trace(msg: &str) -> Result<i32> {
+pub fn trace(msg: &str) {
     // Use an empty slice's pointer instead of null to satisfy Rust's safety requirements
     // Even for zero-length slices, `slice::from_raw_parts` requires a non-null, aligned pointer
     let empty_data: &[u8] = &[];
 
-    let result_code = unsafe {
+    unsafe {
         host::trace(
             msg.as_ptr(),
             msg.len(),
@@ -38,9 +36,7 @@ pub fn trace(msg: &str) -> Result<i32> {
             0usize,
             DataRepr::AsUTF8 as _,
         )
-    };
-
-    match_result_code(result_code, || result_code)
+    }
 }
 
 /// Write the contents of a message to the xrpld trace log.
@@ -54,14 +50,12 @@ pub fn trace(msg: &str) -> Result<i32> {
 /// the number of message bytes that were written to the trace function. Non-zero values indicate
 /// an error (e.g., incorrect buffer sizes).
 #[inline(always)] // <-- Inline because this function is very small
-pub fn trace_data(msg: &str, data: &[u8], data_repr: DataRepr) -> Result<i32> {
-    let result_code = unsafe {
+pub fn trace_data(msg: &str, data: &[u8], data_repr: DataRepr) {
+    unsafe {
         let data_ptr = data.as_ptr();
         let data_len = data.len();
         host::trace(msg.as_ptr(), msg.len(), data_ptr, data_len, data_repr as _)
     };
-
-    match_result_code(result_code, || result_code)
 }
 
 /// Write the contents of a message, and a number, to the xrpld trace log.
@@ -76,53 +70,46 @@ pub fn trace_data(msg: &str, data: &[u8], data_repr: DataRepr) -> Result<i32> {
 /// the number of message bytes that were written to the trace function. Non-zero values indicate
 /// an error (e.g., incorrect buffer sizes).
 #[inline(always)]
-pub fn trace_num(msg: &str, number: i64) -> Result<i32> {
-    let result_code = unsafe { host::trace_num(msg.as_ptr(), msg.len(), number) };
-    match_result_code(result_code, || result_code)
+pub fn trace_num(msg: &str, number: i64) {
+    unsafe { host::trace_num(msg.as_ptr(), msg.len(), number) };
 }
 
 #[inline(always)]
-pub fn trace_acct_buf(msg: &str, account_id: &[u8; 20]) -> Result<i32> {
-    let result_code = unsafe {
+pub fn trace_acct_buf(msg: &str, account_id: &[u8; 20]) {
+    unsafe {
         host::trace_acct(
             msg.as_ptr(),
             msg.len(),
             account_id.as_ptr(),
             account_id.len(),
         )
-    };
-    match_result_code(result_code, || result_code)
+    }
 }
 
 #[inline(always)]
-pub fn trace_acct(msg: &str, account_id: &AccountID) -> Result<i32> {
-    let result_code = unsafe {
+pub fn trace_acct(msg: &str, account_id: &AccountID) {
+    unsafe {
         host::trace_acct(
             msg.as_ptr(),
             msg.len(),
             account_id.0.as_ptr(),
             account_id.0.len(),
         )
-    };
-    match_result_code(result_code, || result_code)
+    }
 }
 
 #[inline(always)]
-pub fn trace_amt(msg: &str, amount: &Amount) -> Result<i32> {
+pub fn trace_amt(msg: &str, amount: &Amount) {
     // Convert Amount to the STAmount format expected by the host trace function
     let (amount_bytes, len) = amount.to_stamount_bytes();
 
-    let result_code =
-        unsafe { host::trace_amt(msg.as_ptr(), msg.len(), amount_bytes.as_ptr(), len) };
-
-    match_result_code(result_code, || result_code)
+    unsafe { host::trace_amt(msg.as_ptr(), msg.len(), amount_bytes.as_ptr(), len) };
 }
 
 /// Write a float to the XRPLD trace log
 #[inline(always)]
-pub fn trace_float(msg: &str, f: &[u8; 8]) -> Result<i32> {
-    let result_code = unsafe { host::trace_xfloat(msg.as_ptr(), msg.len(), f.as_ptr(), 8) };
-    match_result_code(result_code, || result_code)
+pub fn trace_float(msg: &str, f: &[u8; 8]) {
+    unsafe { host::trace_xfloat(msg.as_ptr(), msg.len(), f.as_ptr(), 8) };
 }
 
 #[cfg(test)]
@@ -142,7 +129,7 @@ mod tests {
         // Set up expectations for trace_amt call
         mock.expect_trace_amt()
             .with(always(), always(), always(), always())
-            .returning(move |_, msg_len, _, _| msg_len as i32);
+            .returning(|_, _, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -151,12 +138,9 @@ mod tests {
             num_drops: 1_000_000,
         };
 
-        // Call trace_amt function
-        let result = trace_amt(message, &amount);
-
-        // Should return Ok with the message length
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), message.len() as i32);
+        // Smoke test only: trace is fire-and-forget, and the mock matches any arguments, so
+        // there is nothing to assert beyond the call not panicking.
+        trace_amt(message, &amount);
     }
 
     #[test]
@@ -168,7 +152,7 @@ mod tests {
         // Set up expectations for trace_amt call
         mock.expect_trace_amt()
             .with(always(), always(), always(), always())
-            .returning(move |_, msg_len, _, _| msg_len as i32);
+            .returning(|_, _, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -188,12 +172,9 @@ mod tests {
             mpt_id,
         };
 
-        // Call trace_amt function
-        let result = trace_amt(message, &amount);
-
-        // Should return Ok with the message length
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), message.len() as i32);
+        // Smoke test only: trace is fire-and-forget, and the mock matches any arguments, so
+        // there is nothing to assert beyond the call not panicking.
+        trace_amt(message, &amount);
     }
 
     #[test]
@@ -205,7 +186,7 @@ mod tests {
         // Set up expectations for trace_amt call
         mock.expect_trace_amt()
             .with(always(), always(), always(), always())
-            .returning(move |_, msg_len, _, _| msg_len as i32);
+            .returning(|_, _, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -228,12 +209,9 @@ mod tests {
             currency,
         };
 
-        // Call trace_amt function
-        let result = trace_amt(message, &amount);
-
-        // Should return Ok with the message length
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), message.len() as i32);
+        // Smoke test only: trace is fire-and-forget, and the mock matches any arguments, so
+        // there is nothing to assert beyond the call not panicking.
+        trace_amt(message, &amount);
     }
 
     #[test]
@@ -245,7 +223,7 @@ mod tests {
         // Set up expectations for trace_amt call
         mock.expect_trace_amt()
             .with(always(), always(), always(), always())
-            .returning(move |_, msg_len, _, _| msg_len as i32);
+            .returning(|_, _, _, _| ());
 
         let _guard = setup_mock(mock);
 
@@ -254,12 +232,9 @@ mod tests {
             num_drops: -1_000_000,
         };
 
-        // Call trace_amt function
-        let result = trace_amt(message, &amount);
-
-        // Should return Ok with the message length
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), message.len() as i32);
+        // Smoke test only: trace is fire-and-forget, and the mock matches any arguments, so
+        // there is nothing to assert beyond the call not panicking.
+        trace_amt(message, &amount);
     }
 
     #[test]

--- a/xrpl-common-stdlib/src/ledger_entry_ids.rs
+++ b/xrpl-common-stdlib/src/ledger_entry_ids.rs
@@ -43,10 +43,10 @@ pub type LedgerEntryIdBytes = [u8; XRPL_LEDGER_ENTRY_ID_SIZE];
 ///   );
 ///   match accountroot_id(&account){
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -99,10 +99,10 @@ pub fn accountroot_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 ///  let issue2 = Issue::IOU(IouIssue::new(issuer, currency));
 ///  match amm_id(&issue1, &issue2) {
 ///    xrpl_common_stdlib::host::Result::Ok(id) => {
-///      let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///      trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///    }
 ///    xrpl_common_stdlib::host::Result::Err(e) => {
-///      let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///      trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///    }
 ///  }
 ///  Ok(())
@@ -157,10 +157,10 @@ pub fn amm_id(issue1: &Issue, issue2: &Issue) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match check_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -214,10 +214,10 @@ pub fn check_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///     let cred_type: &[u8] = b"termsandconditions";
 ///     match credential_id(&subject, &issuer, cred_type) {
 ///       xrpl_common_stdlib::host::Result::Ok(id) => {
-///         let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///         trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///       }
 ///       xrpl_common_stdlib::host::Result::Err(e) => {
-///         let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///         trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///       }
 ///     }
 ///     Ok(())
@@ -274,10 +274,10 @@ pub fn credential_id(
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match delegate_id(&account, &authorize) {
 ///       xrpl_common_stdlib::host::Result::Ok(id) => {
-///         let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///         trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///       }
 ///       xrpl_common_stdlib::host::Result::Err(e) => {
-///         let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///         trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///       }
 ///     }
 ///     Ok(())
@@ -328,10 +328,10 @@ pub fn delegate_id(account: &AccountID, authorize: &AccountID) -> Result<LedgerE
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match deposit_preauth_id(&account, &authorize) {
 ///       xrpl_common_stdlib::host::Result::Ok(id) => {
-///         let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///         trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///       }
 ///       xrpl_common_stdlib::host::Result::Err(e) => {
-///         let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///         trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///       }
 ///     }
 ///     Ok(())
@@ -386,10 +386,10 @@ pub fn deposit_preauth_id(
 ///   );
 ///   match did_id(&account){
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -440,10 +440,10 @@ pub fn did_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match escrow_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -499,10 +499,10 @@ pub fn escrow_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///  let currency: Currency = Currency::from(*currency);
 ///  match trustline_id(&account1, &account2, &currency) {
 ///    xrpl_common_stdlib::host::Result::Ok(id) => {
-///      let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///      trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///    }
 ///    xrpl_common_stdlib::host::Result::Err(e) => {
-///      let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///      trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///    }
 ///  }
 ///  Ok(())
@@ -561,10 +561,10 @@ pub fn trustline_id(
 ///   let sequence = 12345;
 ///   match mpt_issuance_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -618,10 +618,10 @@ pub fn mpt_issuance_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match mptoken_id(&mptid, &holder) {
 ///       xrpl_common_stdlib::host::Result::Ok(id) => {
-///         let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///         trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///       }
 ///       xrpl_common_stdlib::host::Result::Err(e) => {
-///         let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///         trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///       }
 ///     }
 ///     Ok(())
@@ -674,10 +674,10 @@ pub fn mptoken_id(mptid: &MptId, holder: &AccountID) -> Result<LedgerEntryIdByte
 ///   let sequence = 12345;
 ///   match nft_offer_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -731,10 +731,10 @@ pub fn nft_offer_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match offer_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -788,10 +788,10 @@ pub fn offer_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///   let document_id = 12345;
 ///   match oracle_id(&owner, document_id) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -848,10 +848,10 @@ pub fn oracle_id(owner: &AccountID, document_id: u32) -> Result<LedgerEntryIdByt
 ///   let sequence = 12345;
 ///   match paychan_id(&account, &destination, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -911,10 +911,10 @@ pub fn paychan_id(
 ///   let sequence = 12345;
 ///   match permissioned_domain_id(&account, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -967,10 +967,10 @@ pub fn permissioned_domain_id(account: &AccountID, seq: u32) -> Result<LedgerEnt
 ///   );
 ///   match signers_id(&account){
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -1021,10 +1021,10 @@ pub fn signers_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match ticket_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -1078,10 +1078,10 @@ pub fn ticket_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match vault_id(&account, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       let _ = trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling ledger entry ID", e.code() as i64);
+///       trace_num("Error assembling ledger entry ID", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())

--- a/xrpl-common-stdlib/src/ledger_entry_ids.rs
+++ b/xrpl-common-stdlib/src/ledger_entry_ids.rs
@@ -36,14 +36,14 @@ pub type LedgerEntryIdBytes = [u8; XRPL_LEDGER_ENTRY_ID_SIZE];
 ///
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::accountroot_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let account:AccountID = AccountID::from(
 ///     *b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3"
 ///   );
 ///   match accountroot_id(&account){
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -89,7 +89,7 @@ pub fn accountroot_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 /// use xrpl_common_stdlib::types::issue::{Issue, XrpIssue, IouIssue};
 /// use xrpl_common_stdlib::types::currency::Currency;
 /// use xrpl_common_stdlib::ledger_entry_ids::amm_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///  let issue1: Issue = Issue::XRP(XrpIssue {});
 ///  let issuer: AccountID =
@@ -99,7 +99,7 @@ pub fn accountroot_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 ///  let issue2 = Issue::IOU(IouIssue::new(issuer, currency));
 ///  match amm_id(&issue1, &issue2) {
 ///    xrpl_common_stdlib::host::Result::Ok(id) => {
-///      trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///      trace_hex("Generated ledger entry ID", &id);
 ///    }
 ///    xrpl_common_stdlib::host::Result::Err(e) => {
 ///      trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -149,7 +149,7 @@ pub fn amm_id(issue1: &Issue, issue2: &Issue) -> Result<LedgerEntryIdBytes> {
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::check_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let owner: AccountID =
@@ -157,7 +157,7 @@ pub fn amm_id(issue1: &Issue, issue2: &Issue) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match check_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -205,7 +205,7 @@ pub fn check_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::credential_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let subject: AccountID =
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
@@ -214,7 +214,7 @@ pub fn check_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///     let cred_type: &[u8] = b"termsandconditions";
 ///     match credential_id(&subject, &issuer, cred_type) {
 ///       xrpl_common_stdlib::host::Result::Ok(id) => {
-///         trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///         trace_hex("Generated ledger entry ID", &id);
 ///       }
 ///       xrpl_common_stdlib::host::Result::Err(e) => {
 ///         trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -266,7 +266,7 @@ pub fn credential_id(
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::delegate_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let account: AccountID =
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
@@ -274,7 +274,7 @@ pub fn credential_id(
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match delegate_id(&account, &authorize) {
 ///       xrpl_common_stdlib::host::Result::Ok(id) => {
-///         trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///         trace_hex("Generated ledger entry ID", &id);
 ///       }
 ///       xrpl_common_stdlib::host::Result::Err(e) => {
 ///         trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -320,7 +320,7 @@ pub fn delegate_id(account: &AccountID, authorize: &AccountID) -> Result<LedgerE
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::deposit_preauth_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let account: AccountID =
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
@@ -328,7 +328,7 @@ pub fn delegate_id(account: &AccountID, authorize: &AccountID) -> Result<LedgerE
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match deposit_preauth_id(&account, &authorize) {
 ///       xrpl_common_stdlib::host::Result::Ok(id) => {
-///         trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///         trace_hex("Generated ledger entry ID", &id);
 ///       }
 ///       xrpl_common_stdlib::host::Result::Err(e) => {
 ///         trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -379,14 +379,14 @@ pub fn deposit_preauth_id(
 ///
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::did_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let account:AccountID = AccountID::from(
 ///     *b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3"
 ///   );
 ///   match did_id(&account){
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -432,7 +432,7 @@ pub fn did_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::escrow_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let owner: AccountID =
@@ -440,7 +440,7 @@ pub fn did_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match escrow_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -489,7 +489,7 @@ pub fn escrow_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::types::currency::Currency;
 /// use xrpl_common_stdlib::ledger_entry_ids::trustline_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///  let account1: AccountID =
 ///    AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
@@ -499,7 +499,7 @@ pub fn escrow_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///  let currency: Currency = Currency::from(*currency);
 ///  match trustline_id(&account1, &account2, &currency) {
 ///    xrpl_common_stdlib::host::Result::Ok(id) => {
-///      trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///      trace_hex("Generated ledger entry ID", &id);
 ///    }
 ///    xrpl_common_stdlib::host::Result::Err(e) => {
 ///      trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -553,7 +553,7 @@ pub fn trustline_id(
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::mpt_issuance_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let owner: AccountID =
@@ -561,7 +561,7 @@ pub fn trustline_id(
 ///   let sequence = 12345;
 ///   match mpt_issuance_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -609,7 +609,7 @@ pub fn mpt_issuance_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::types::mpt_id::MptId;
 /// use xrpl_common_stdlib::ledger_entry_ids::mptoken_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let issuer: AccountID =
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
@@ -618,7 +618,7 @@ pub fn mpt_issuance_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match mptoken_id(&mptid, &holder) {
 ///       xrpl_common_stdlib::host::Result::Ok(id) => {
-///         trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///         trace_hex("Generated ledger entry ID", &id);
 ///       }
 ///       xrpl_common_stdlib::host::Result::Err(e) => {
 ///         trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -666,7 +666,7 @@ pub fn mptoken_id(mptid: &MptId, holder: &AccountID) -> Result<LedgerEntryIdByte
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::nft_offer_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let owner: AccountID =
@@ -674,7 +674,7 @@ pub fn mptoken_id(mptid: &MptId, holder: &AccountID) -> Result<LedgerEntryIdByte
 ///   let sequence = 12345;
 ///   match nft_offer_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -723,7 +723,7 @@ pub fn nft_offer_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::offer_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let owner: AccountID =
@@ -731,7 +731,7 @@ pub fn nft_offer_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match offer_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -780,7 +780,7 @@ pub fn offer_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::oracle_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let owner: AccountID =
@@ -788,7 +788,7 @@ pub fn offer_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///   let document_id = 12345;
 ///   match oracle_id(&owner, document_id) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -838,7 +838,7 @@ pub fn oracle_id(owner: &AccountID, document_id: u32) -> Result<LedgerEntryIdByt
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::paychan_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let account: AccountID =
@@ -848,7 +848,7 @@ pub fn oracle_id(owner: &AccountID, document_id: u32) -> Result<LedgerEntryIdByt
 ///   let sequence = 12345;
 ///   match paychan_id(&account, &destination, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -903,7 +903,7 @@ pub fn paychan_id(
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::permissioned_domain_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let account: AccountID =
@@ -911,7 +911,7 @@ pub fn paychan_id(
 ///   let sequence = 12345;
 ///   match permissioned_domain_id(&account, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -960,14 +960,14 @@ pub fn permissioned_domain_id(account: &AccountID, seq: u32) -> Result<LedgerEnt
 ///
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::signers_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let account:AccountID = AccountID::from(
 ///     *b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3"
 ///   );
 ///   match signers_id(&account){
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -1013,7 +1013,7 @@ pub fn signers_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::ticket_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let owner: AccountID =
@@ -1021,7 +1021,7 @@ pub fn signers_id(account_id: &AccountID) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match ticket_id(&owner, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);
@@ -1070,7 +1070,7 @@ pub fn ticket_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 /// ```rust
 /// use xrpl_common_stdlib::types::account_id::AccountID;
 /// use xrpl_common_stdlib::ledger_entry_ids::vault_id;
-/// use xrpl_common_stdlib::host::trace::{DataRepr, trace_data, trace_num};
+/// use xrpl_common_stdlib::host::trace::{ trace_hex, trace_num };
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///   let account: AccountID =
@@ -1078,7 +1078,7 @@ pub fn ticket_id(owner: &AccountID, seq: u32) -> Result<LedgerEntryIdBytes> {
 ///   let sequence = 12345;
 ///   match vault_id(&account, sequence) {
 ///     xrpl_common_stdlib::host::Result::Ok(id) => {
-///       trace_data("Generated ledger entry ID", &id, DataRepr::AsHex);
+///       trace_hex("Generated ledger entry ID", &id);
 ///     }
 ///     xrpl_common_stdlib::host::Result::Err(e) => {
 ///       trace_num("Error assembling ledger entry ID", e.code() as i64);

--- a/xrpl-common-stdlib/src/ledger_entry_ids.rs
+++ b/xrpl-common-stdlib/src/ledger_entry_ids.rs
@@ -1126,7 +1126,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::host::error_codes::INTERNAL_ERROR;
+    use crate::host::error_codes::SOME_ERROR;
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::host::setup_mock;
 
@@ -1160,17 +1160,17 @@ mod tests {
         };
     }
 
-    /// Generates a mock `returning` closure that returns INTERNAL_ERROR.
+    /// Generates a mock `returning` closure that returns SOME_ERROR.
     /// Pass the total number of parameters of the host function.
     macro_rules! error_returning {
         (4) => {
-            |_, _, _, _| INTERNAL_ERROR
+            |_, _, _, _| SOME_ERROR
         };
         (6) => {
-            |_, _, _, _, _, _| INTERNAL_ERROR
+            |_, _, _, _, _, _| SOME_ERROR
         };
         (8) => {
-            |_, _, _, _, _, _, _, _| INTERNAL_ERROR
+            |_, _, _, _, _, _, _, _| SOME_ERROR
         };
     }
 
@@ -1210,7 +1210,7 @@ mod tests {
 
                     let result = $call_block;
                     assert!(result.is_err());
-                    assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+                    assert_eq!(result.err().unwrap().code(), SOME_ERROR);
                 }
             }
         };

--- a/xrpl-common-stdlib/src/objects/traits.rs
+++ b/xrpl-common-stdlib/src/objects/traits.rs
@@ -132,7 +132,7 @@ pub trait CurrentLedgerObjectCommonFields {
 mod tests {
     use super::*;
     use crate::fields::decoder::FromLedger;
-    use crate::host::error_codes::{INTERNAL_ERROR, INVALID_FIELD};
+    use crate::host::error_codes::{INVALID_FIELD, SOME_ERROR};
     use crate::host::host_bindings_trait::MockHostBindings;
     use crate::objects::AccountRoot;
     use crate::sfield::SField;
@@ -216,11 +216,11 @@ mod tests {
         fn test_mandatory_fields_return_error_on_internal_error() {
             let mut mock = MockHostBindings::new();
 
-            // get_flags with INTERNAL_ERROR
+            // get_flags with SOME_ERROR
             mock.expect_le_field()
                 .with(eq(1), eq(sfield::Flags), always(), eq(4))
                 .times(1)
-                .returning(|_, _, _, _| INTERNAL_ERROR);
+                .returning(|_, _, _, _| SOME_ERROR);
 
             let _guard = setup_mock(mock);
 
@@ -228,7 +228,7 @@ mod tests {
             let result = account.get_flags();
 
             assert!(result.is_err());
-            assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+            assert_eq!(result.err().unwrap().code(), SOME_ERROR);
         }
 
         #[test]
@@ -238,7 +238,7 @@ mod tests {
             mock.expect_le_field()
                 .with(eq(1), eq(sfield::LedgerEntryType), always(), eq(2))
                 .times(1)
-                .returning(|_, _, _, _| INTERNAL_ERROR);
+                .returning(|_, _, _, _| SOME_ERROR);
 
             let _guard = setup_mock(mock);
 
@@ -246,7 +246,7 @@ mod tests {
             let result = account.get_ledger_entry_type();
 
             assert!(result.is_err());
-            assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+            assert_eq!(result.err().unwrap().code(), SOME_ERROR);
         }
 
         #[test]
@@ -298,11 +298,11 @@ mod tests {
         fn test_mandatory_fields_return_error_on_internal_error() {
             let mut mock = MockHostBindings::new();
 
-            // get_flags with INTERNAL_ERROR
+            // get_flags with SOME_ERROR
             mock.expect_home_le_field()
                 .with(eq(sfield::Flags), always(), eq(4))
                 .times(1)
-                .returning(|_, _, _| INTERNAL_ERROR);
+                .returning(|_, _, _| SOME_ERROR);
 
             let _guard = setup_mock(mock);
 
@@ -310,7 +310,7 @@ mod tests {
             let result = escrow.get_flags();
 
             assert!(result.is_err());
-            assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+            assert_eq!(result.err().unwrap().code(), SOME_ERROR);
         }
 
         #[test]
@@ -320,7 +320,7 @@ mod tests {
             mock.expect_home_le_field()
                 .with(eq(sfield::LedgerEntryType), always(), eq(2))
                 .times(1)
-                .returning(|_, _, _| INTERNAL_ERROR);
+                .returning(|_, _, _| SOME_ERROR);
 
             let _guard = setup_mock(mock);
 
@@ -328,7 +328,7 @@ mod tests {
             let result = escrow.get_ledger_entry_type();
 
             assert!(result.is_err());
-            assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+            assert_eq!(result.err().unwrap().code(), SOME_ERROR);
         }
 
         #[test]

--- a/xrpl-common-stdlib/src/types/nft.rs
+++ b/xrpl-common-stdlib/src/types/nft.rs
@@ -531,7 +531,7 @@ mod tests {
 
         mock.expect_nft_flags()
             .with(always(), eq(NFT_ID_SIZE))
-            .returning(|_, _| crate::host::error_codes::INTERNAL_ERROR);
+            .returning(|_, _| crate::host::error_codes::SOME_ERROR);
 
         let _guard = setup_mock(mock);
 
@@ -540,7 +540,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().code(),
-            crate::host::error_codes::INTERNAL_ERROR
+            crate::host::error_codes::SOME_ERROR
         );
     }
 

--- a/xrpl-common-stdlib/tests/decoder/fail_array_field_not_readable.stderr
+++ b/xrpl-common-stdlib/tests/decoder/fail_array_field_not_readable.stderr
@@ -8,13 +8,13 @@ error[E0277]: the trait bound `Array: FromLedger` is not satisfied
   |
   = help: the following other types implement trait `FromLedger`:
             AccountID
-            Amount
             Blob<N>
             Currency
             Issue
             Number
             UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
             UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
+            UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
           and $N others
 note: required by a bound in `xrpl_common_stdlib::fields::ledger_obj::get_field`
  --> src/fields/ledger_obj.rs

--- a/xrpl-common-stdlib/tests/decoder/fail_obj_only_missing_from_current_tx.stderr
+++ b/xrpl-common-stdlib/tests/decoder/fail_obj_only_missing_from_current_tx.stderr
@@ -6,13 +6,13 @@ error[E0277]: the trait bound `ObjOnly: FromCurrentTx` is not satisfied
    |
    = help: the following other types implement trait `FromCurrentTx`:
              AccountID
-             Amount
              Blob<N>
              Number
              TransactionType
              UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt256::{constant#0}>
            and $N others
 note: required by a bound in `requires_from_current_tx`
   --> tests/decoder/fail_obj_only_missing_from_current_tx.rs:23:32

--- a/xrpl-common-stdlib/tests/decoder/fail_object_field_not_readable.stderr
+++ b/xrpl-common-stdlib/tests/decoder/fail_object_field_not_readable.stderr
@@ -8,13 +8,13 @@ error[E0277]: the trait bound `Object: FromLedger` is not satisfied
   |
   = help: the following other types implement trait `FromLedger`:
             AccountID
-            Amount
             Blob<N>
             Currency
             Issue
             Number
             UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
             UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
+            UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
           and $N others
 note: required by a bound in `xrpl_common_stdlib::fields::current_ledger_obj::get_field`
  --> src/fields/current_ledger_obj.rs

--- a/xrpl-common-stdlib/tests/decoder/fail_tx_only_missing_from_ledger.stderr
+++ b/xrpl-common-stdlib/tests/decoder/fail_tx_only_missing_from_ledger.stderr
@@ -6,13 +6,13 @@ error[E0277]: the trait bound `TxOnly: FromLedger` is not satisfied
    |
    = help: the following other types implement trait `FromLedger`:
              AccountID
-             Amount
              Blob<N>
              Currency
              Issue
              Number
              UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
            and $N others
 note: required by a bound in `requires_from_ledger`
   --> tests/decoder/fail_tx_only_missing_from_ledger.rs:23:28

--- a/xrpl-common-stdlib/tests/locator/fail_get_array_not_readable.stderr
+++ b/xrpl-common-stdlib/tests/locator/fail_get_array_not_readable.stderr
@@ -8,13 +8,13 @@ error[E0277]: the trait bound `Array: FromCurrentTx` is not satisfied
    |
    = help: the following other types implement trait `FromCurrentTx`:
              AccountID
-             Amount
              Blob<N>
              Number
              TransactionType
              UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt256::{constant#0}>
            and $N others
 note: required by a bound in `TxPathBuilder::get`
   --> src/fields/locator.rs

--- a/xrpl-common-stdlib/tests/locator/fail_get_from_ledger_only.stderr
+++ b/xrpl-common-stdlib/tests/locator/fail_get_from_ledger_only.stderr
@@ -8,13 +8,13 @@ error[E0277]: the trait bound `LedgerOnly: FromCurrentTx` is not satisfied
    |
    = help: the following other types implement trait `FromCurrentTx`:
              AccountID
-             Amount
              Blob<N>
              Number
              TransactionType
              UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt256::{constant#0}>
            and $N others
 note: required by a bound in `TxPathBuilder::get`
   --> src/fields/locator.rs

--- a/xrpl-common-stdlib/tests/locator/fail_ledger_get_array_not_readable.stderr
+++ b/xrpl-common-stdlib/tests/locator/fail_ledger_get_array_not_readable.stderr
@@ -8,13 +8,13 @@ error[E0277]: the trait bound `Array: FromLedger` is not satisfied
    |
    = help: the following other types implement trait `FromLedger`:
              AccountID
-             Amount
              Blob<N>
              Currency
              Issue
              Number
              UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
            and $N others
 note: required by a bound in `LedgerPathBuilder::get`
   --> src/fields/locator.rs

--- a/xrpl-common-stdlib/tests/locator/fail_ledger_get_from_current_tx_only.stderr
+++ b/xrpl-common-stdlib/tests/locator/fail_ledger_get_from_current_tx_only.stderr
@@ -8,13 +8,13 @@ error[E0277]: the trait bound `TxOnly: FromLedger` is not satisfied
    |
    = help: the following other types implement trait `FromLedger`:
              AccountID
-             Amount
              Blob<N>
              Currency
              Issue
              Number
              UInt<xrpl_common_stdlib::::types::uint::UInt128::{constant#0}>
              UInt<xrpl_common_stdlib::::types::uint::UInt160::{constant#0}>
+             UInt<xrpl_common_stdlib::::types::uint::UInt192::{constant#0}>
            and $N others
 note: required by a bound in `LedgerPathBuilder::get`
   --> src/fields/locator.rs

--- a/xrpl-escrow-stdlib/src/ctx/escrow_finish.rs
+++ b/xrpl-escrow-stdlib/src/ctx/escrow_finish.rs
@@ -82,7 +82,9 @@ mod tests {
     #[test]
     fn set_data_returns_err_on_negative_code() {
         let _guard = EscrowScenario::builder()
-            .with_set_data_returns(Err(Error::InternalError))
+            .with_set_data_returns(Err(Error::from_code(
+                xrpl_common_stdlib::host::error_codes::SOME_ERROR,
+            )))
             .install();
 
         let ctx = EscrowFinishContext::default();

--- a/xrpl-escrow-stdlib/src/current_tx/traits.rs
+++ b/xrpl-escrow-stdlib/src/current_tx/traits.rs
@@ -152,7 +152,7 @@ mod tests {
             use crate::current_tx::traits::EscrowFinishFields;
             use crate::current_tx::traits::tests::expect_tx_field;
             use xrpl_common_stdlib::host::error_codes::{
-                FIELD_NOT_FOUND, INTERNAL_ERROR, INVALID_FIELD,
+                FIELD_NOT_FOUND, INVALID_FIELD, SOME_ERROR,
             };
             use xrpl_common_stdlib::host::host_bindings_trait::MockHostBindings;
             use xrpl_common_stdlib::host::setup_mock;
@@ -217,25 +217,25 @@ mod tests {
                 mock.expect_tx_field()
                     .with(eq(sfield::Condition), always(), eq(CONDITION_BLOB_SIZE))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_fulfillment
                 mock.expect_tx_field()
                     .with(eq(sfield::Fulfillment), always(), eq(FULFILLMENT_BLOB_SIZE))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
 
                 let _guard = setup_mock(mock);
 
                 let escrow = EscrowFinish;
 
-                // Optional fields should also return Err on INTERNAL_ERROR
+                // Optional fields should also return Err on SOME_ERROR
                 let condition_result = escrow.get_condition();
                 assert!(condition_result.is_err());
-                assert_eq!(condition_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(condition_result.err().unwrap().code(), SOME_ERROR);
 
                 let fulfillment_result = escrow.get_fulfillment();
                 assert!(fulfillment_result.is_err());
-                assert_eq!(fulfillment_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(fulfillment_result.err().unwrap().code(), SOME_ERROR);
             }
 
             #[test]
@@ -303,7 +303,7 @@ mod tests {
             use crate::current_tx::traits::tests::expect_tx_field;
             use mockall::predicate::{always, eq};
             use xrpl_common_stdlib::host::error_codes::{
-                FIELD_NOT_FOUND, INTERNAL_ERROR, INVALID_FIELD,
+                FIELD_NOT_FOUND, INVALID_FIELD, SOME_ERROR,
             };
             use xrpl_common_stdlib::host::host_bindings_trait::MockHostBindings;
             use xrpl_common_stdlib::host::setup_mock;
@@ -402,25 +402,25 @@ mod tests {
                 mock.expect_tx_field()
                     .with(eq(sfield::Owner), always(), eq(ACCOUNT_ID_SIZE))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
                 // get_offer_sequence
                 mock.expect_tx_field()
                     .with(eq(sfield::OfferSequence), always(), eq(4))
                     .times(1)
-                    .returning(|_, _, _| INTERNAL_ERROR);
+                    .returning(|_, _, _| SOME_ERROR);
 
                 let _guard = setup_mock(mock);
 
                 let escrow = EscrowFinish;
 
-                // All mandatory fields should return Err on INTERNAL_ERROR
+                // All mandatory fields should return Err on SOME_ERROR
                 let owner_result = escrow.get_owner();
                 assert!(owner_result.is_err());
-                assert_eq!(owner_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(owner_result.err().unwrap().code(), SOME_ERROR);
 
                 let offer_seq_result = escrow.get_offer_sequence();
                 assert!(offer_seq_result.is_err());
-                assert_eq!(offer_seq_result.err().unwrap().code(), INTERNAL_ERROR);
+                assert_eq!(offer_seq_result.err().unwrap().code(), SOME_ERROR);
             }
 
             #[test]

--- a/xrpl-escrow-stdlib/src/ledger_objects/escrow_storage.rs
+++ b/xrpl-escrow-stdlib/src/ledger_objects/escrow_storage.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
     use mockall::predicate::{always, eq};
     use xrpl_common_stdlib::host::Error;
-    use xrpl_common_stdlib::host::error_codes::INTERNAL_ERROR;
+    use xrpl_common_stdlib::host::error_codes::SOME_ERROR;
     use xrpl_common_stdlib::host::host_bindings_trait::MockHostBindings;
     use xrpl_common_stdlib::host::setup_mock;
     use xrpl_common_stdlib::sfield;
@@ -56,7 +56,7 @@ mod tests {
 
         fn decode(bytes: &[u8]) -> Result<Self> {
             if bytes.len() < 4 {
-                return Result::Err(Error::InternalError);
+                return Result::Err(Error::InvalidDecoding);
             }
             let mut header = [0u8; 4];
             header.copy_from_slice(&bytes[..4]);
@@ -110,13 +110,13 @@ mod tests {
     #[test]
     fn load_data_propagates_host_error() {
         let mut mock = MockHostBindings::new();
-        expect_get_data(&mut mock, INTERNAL_ERROR, None);
+        expect_get_data(&mut mock, SOME_ERROR, None);
         let _guard = setup_mock(mock);
 
         let ctx = EscrowFinishContext::default();
         let result: Result<Option<TestPayload>> = load_data(&ctx);
 
-        assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+        assert_eq!(result.err().unwrap().code(), SOME_ERROR);
     }
 
     #[test]
@@ -154,12 +154,17 @@ mod tests {
     #[test]
     fn save_data_propagates_host_error_without_swallowing_it() {
         let _guard = EscrowScenario::builder()
-            .with_set_data_returns(Err(Error::InternalError))
+            .with_set_data_returns(Err(Error::from_code(
+                xrpl_common_stdlib::host::error_codes::SOME_ERROR,
+            )))
             .install();
 
         let ctx = EscrowFinishContext::default();
         let result = save_data(&ctx, &TestPayload(42));
 
-        assert_eq!(result.err().unwrap().code(), Error::InternalError.code());
+        assert_eq!(
+            result.err().unwrap().code(),
+            Error::from_code(xrpl_common_stdlib::host::error_codes::SOME_ERROR).code()
+        );
     }
 }

--- a/xrpl-escrow-stdlib/src/ledger_objects/traits.rs
+++ b/xrpl-escrow-stdlib/src/ledger_objects/traits.rs
@@ -143,7 +143,7 @@ mod tests {
     use super::*;
     use mockall::predicate::{always, eq};
     use xrpl_common_stdlib::fields::decoder::FromLedger;
-    use xrpl_common_stdlib::host::error_codes::{FIELD_NOT_FOUND, INTERNAL_ERROR, INVALID_FIELD};
+    use xrpl_common_stdlib::host::error_codes::{FIELD_NOT_FOUND, INVALID_FIELD, SOME_ERROR};
     use xrpl_common_stdlib::host::host_bindings_trait::MockHostBindings;
     use xrpl_common_stdlib::sfield::SField;
 
@@ -301,11 +301,11 @@ mod tests {
         fn test_mandatory_fields_return_error_on_internal_error() {
             let mut mock = MockHostBindings::new();
 
-            // get_account with INTERNAL_ERROR
+            // get_account with SOME_ERROR
             mock.expect_home_le_field()
                 .with(eq(sfield::Account), always(), eq(20))
                 .times(1)
-                .returning(|_, _, _| INTERNAL_ERROR);
+                .returning(|_, _, _| SOME_ERROR);
 
             let _guard = setup_mock(mock);
 
@@ -313,7 +313,7 @@ mod tests {
             let result = escrow.get_account();
 
             assert!(result.is_err());
-            assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+            assert_eq!(result.err().unwrap().code(), SOME_ERROR);
         }
 
         #[test]
@@ -323,7 +323,7 @@ mod tests {
             mock.expect_home_le_field()
                 .with(eq(sfield::Data), always(), eq(XRPL_CONTRACT_DATA_SIZE))
                 .times(1)
-                .returning(|_, _, _| INTERNAL_ERROR);
+                .returning(|_, _, _| SOME_ERROR);
 
             let _guard = setup_mock(mock);
 
@@ -331,7 +331,7 @@ mod tests {
             let result = escrow.get_data();
 
             assert!(result.is_err());
-            assert_eq!(result.err().unwrap().code(), INTERNAL_ERROR);
+            assert_eq!(result.err().unwrap().code(), SOME_ERROR);
         }
 
         #[test]

--- a/xrpl-stdlib-test-utils/src/mock_escrow.rs
+++ b/xrpl-stdlib-test-utils/src/mock_escrow.rs
@@ -195,12 +195,17 @@ mod tests {
     #[test]
     fn with_set_data_returns_err_reports_the_error_code_through_the_real_host_call() {
         let _guard = EscrowScenario::builder()
-            .with_set_data_returns(Err(Error::InternalError))
+            .with_set_data_returns(Err(Error::from_code(
+                xrpl_common_stdlib::host::error_codes::SOME_ERROR,
+            )))
             .install();
 
         let payload = b"payload";
         let code = unsafe { xrpl_common_stdlib::host::set_data(payload.as_ptr(), payload.len()) };
-        assert_eq!(code, Error::InternalError.code());
+        assert_eq!(
+            code,
+            Error::from_code(xrpl_common_stdlib::host::error_codes::SOME_ERROR).code()
+        );
         assert!(code < 0);
     }
 


### PR DESCRIPTION
Matches the xrpld-side trace refactor. xrpld declares all five trace host functions as `void`, so the stdlib's `-> i32` signature never described the real ABI. They now return nothing, through the `extern "C"` block, the `HostBindings` trait, all three impls, and the public `trace*` helpers. Call sites drop their `let _ =`, which `clippy::let_unit_value` makes an error under `-Dwarnings`.

Also realigns two error codes xrpld reassigned: `-1` is `Unimplemented`, not an internal error, and `-11` is `OutOfTransferLimit`, not a decoding failure. Both displaced concepts are still needed here, so they move into a library-owned range growing upward from `i32::MIN` (`INTERNAL_ERROR` = `i32::MIN`, `INVALID_DECODING` = `i32::MIN + 1`) where they can't collide with a host code. Host codes are the host/guest interface; conditions the stdlib detects itself belong in its own range. `DecodeError` still maps to `InvalidDecoding`, so only the value moves — no call site renames.

`tools/compareHostFunctions.js` required a mandatory `-> T` in all four of its regexes, so unit-returning functions were skipped and then reported as missing from the Rust trait. Fixed to treat an omitted or `-> ()` return as `void`.

Pairs with the xrpld trace2 change and should land alongside it. Until then the host function audit reports five trace return-type differences, which is the expected temporary skew.

Verified: build, clippy, fmt, wasm-exports and markdown checks pass; `cargo test --workspace` is 490 passed / 0 failed. Integration tests need an xrpld node and were not run locally.
