### PR TITLE
release: Bump all four crates to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "xrpl-common-stdlib"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "mockall",
  "trybuild",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "xrpl-escrow-stdlib"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "mockall",
  "trybuild",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "xrpl-macros"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "xrpl-stdlib-test-utils"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "mockall",
  "xrpl-common-stdlib",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -210,21 +210,21 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "xrpl-common-stdlib"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "xrpl-macros",
 ]
 
 [[package]]
 name = "xrpl-escrow-stdlib"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "xrpl-common-stdlib",
 ]
 
 [[package]]
 name = "xrpl-macros"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "bs58",
  "proc-macro2",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -226,21 +226,21 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "xrpl-common-stdlib"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "xrpl-macros",
 ]
 
 [[package]]
 name = "xrpl-escrow-stdlib"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "xrpl-common-stdlib",
 ]
 
 [[package]]
 name = "xrpl-macros"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "bs58",
  "proc-macro2",

--- a/xrpl-common-stdlib/Cargo.toml
+++ b/xrpl-common-stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-common-stdlib"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "Standard library for XRPL WebAssembly smart contracts"
 license.workspace = true
@@ -26,7 +26,7 @@ test-host-bindings = ["dep:mockall"]
 [dependencies]
 # Both `version` and `path` are required on a published sibling crate — see
 # xrpl-escrow-stdlib/Cargo.toml for why.
-xrpl-macros = { version = "0.1.0", path = "../xrpl-macros" }
+xrpl-macros = { version = "0.9.0", path = "../xrpl-macros" }
 mockall = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/xrpl-escrow-stdlib/Cargo.toml
+++ b/xrpl-escrow-stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-escrow-stdlib"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2024"
 description = "Smart Escrow types, entry-point context, and host-function wrappers for XRPL WebAssembly contracts"
 license.workspace = true
@@ -19,7 +19,7 @@ crate-type = ["lib"]
 # in ../xrpl-common-stdlib takes effect immediately. `cargo publish` swaps in `version` instead,
 # because a crate on crates.io cannot point at a directory on the author's machine. Omitting
 # `version` fails packaging with "all dependencies must have a version specified".
-xrpl-common-stdlib = { version = "0.8.0", path = "../xrpl-common-stdlib" }
+xrpl-common-stdlib = { version = "0.9.0", path = "../xrpl-common-stdlib" }
 
 [dev-dependencies]
 xrpl-common-stdlib = { path = "../xrpl-common-stdlib", features = ["test-host-bindings"] }

--- a/xrpl-macros/Cargo.toml
+++ b/xrpl-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-macros"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2024"
 description = "Internal proc macro for xrpl-common-stdlib - use xrpl-common-stdlib instead"
 license.workspace = true

--- a/xrpl-stdlib-test-utils/Cargo.toml
+++ b/xrpl-stdlib-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-stdlib-test-utils"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2024"
 description = "Test harness for XRPL WebAssembly smart contracts: MockHostBindings plus escrow scenario builders"
 license.workspace = true
@@ -16,7 +16,7 @@ include = ["src/", "README.md"]
 # dependency because this crate *is* the harness — consumers gate it out of WASM builds by declaring
 # this crate under `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]` instead.
 # Both `version` and `path` are required — see xrpl-escrow-stdlib/Cargo.toml for why.
-xrpl-common-stdlib = { version = "0.8.0", path = "../xrpl-common-stdlib", features = [
+xrpl-common-stdlib = { version = "0.9.0", path = "../xrpl-common-stdlib", features = [
   "test-host-bindings",
 ] }
 mockall.workspace = true


### PR DESCRIPTION
## High Level Overview of Change

Bumps all four published crates to `0.9.0`, in lockstep, immediately before the first crates.io
publish. Split out of #277 so the publish metadata and docs could merge on their own.

| Crate                    | Before  | After   |
| ------------------------ | ------- | ------- |
| `xrpl-macros`            | `0.1.0` | `0.9.0` |
| `xrpl-common-stdlib`     | `0.8.0` | `0.9.0` |
| `xrpl-stdlib-test-utils` | `0.1.0` | `0.9.0` |
| `xrpl-escrow-stdlib`     | `0.1.0` | `0.9.0` |

### Context of Change

The four crates are versioned in lockstep: every one carries the same version and a release bumps
all of them even if only one changed. That replaces a compatibility matrix with a single rule for
consumers ("use `0.9.x` of everything"). `xrpl-stdlib-test-utils` in particular must match
`xrpl-common-stdlib` exactly, since its mocks are generated from that crate's `HostBindings` trait
and a mismatched pair will not compile.

`0.9.0` continues from `xrpl-wasm-stdlib` `0.8.0`, the library's pre-split name, so the version
line reads continuously across the rename.

Each in-workspace dependency's `version` key is bumped alongside the package versions — leaving
them behind would publish a crate whose manifest points at the previous release. The three
lockfiles are regenerated to match.

Publishing is manual and this PR uploads nothing. See `CONTRIBUTING.md`'s "Release Process" for the
sequence that follows the merge.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (added tests for existing code, or tests for the new feature in this PR)
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [x] Release

## Test Plan

Version numbers only — no source changes. All three workspaces resolve at `0.9.0` and
`./scripts/run-all.sh` passes.
