### PR TITLE
release: Bump to 0.10.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "xrpl-common-stdlib"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "mockall",
  "trybuild",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "xrpl-escrow-stdlib"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "mockall",
  "trybuild",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "xrpl-macros"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "xrpl-stdlib-test-utils"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "mockall",
  "xrpl-common-stdlib",

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -210,21 +210,21 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "xrpl-common-stdlib"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "xrpl-macros",
 ]
 
 [[package]]
 name = "xrpl-escrow-stdlib"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "xrpl-common-stdlib",
 ]
 
 [[package]]
 name = "xrpl-macros"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "bs58",
  "proc-macro2",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -226,21 +226,21 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "xrpl-common-stdlib"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "xrpl-macros",
 ]
 
 [[package]]
 name = "xrpl-escrow-stdlib"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "xrpl-common-stdlib",
 ]
 
 [[package]]
 name = "xrpl-macros"
-version = "0.9.0"
+version = "0.10.0-dev"
 dependencies = [
  "bs58",
  "proc-macro2",

--- a/xrpl-common-stdlib/Cargo.toml
+++ b/xrpl-common-stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-common-stdlib"
-version = "0.9.0"
+version = "0.10.0-dev"
 edition = "2024"
 description = "Standard library for XRPL WebAssembly smart contracts"
 license.workspace = true
@@ -26,7 +26,7 @@ test-host-bindings = ["dep:mockall"]
 [dependencies]
 # Both `version` and `path` are required on a published sibling crate — see
 # xrpl-escrow-stdlib/Cargo.toml for why.
-xrpl-macros = { version = "0.9.0", path = "../xrpl-macros" }
+xrpl-macros = { version = "0.10.0-dev", path = "../xrpl-macros" }
 mockall = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/xrpl-escrow-stdlib/Cargo.toml
+++ b/xrpl-escrow-stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-escrow-stdlib"
-version = "0.9.0"
+version = "0.10.0-dev"
 edition = "2024"
 description = "Smart Escrow types, entry-point context, and host-function wrappers for XRPL WebAssembly contracts"
 license.workspace = true
@@ -19,7 +19,7 @@ crate-type = ["lib"]
 # in ../xrpl-common-stdlib takes effect immediately. `cargo publish` swaps in `version` instead,
 # because a crate on crates.io cannot point at a directory on the author's machine. Omitting
 # `version` fails packaging with "all dependencies must have a version specified".
-xrpl-common-stdlib = { version = "0.9.0", path = "../xrpl-common-stdlib" }
+xrpl-common-stdlib = { version = "0.10.0-dev", path = "../xrpl-common-stdlib" }
 
 [dev-dependencies]
 xrpl-common-stdlib = { path = "../xrpl-common-stdlib", features = ["test-host-bindings"] }

--- a/xrpl-macros/Cargo.toml
+++ b/xrpl-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-macros"
-version = "0.9.0"
+version = "0.10.0-dev"
 edition = "2024"
 description = "Internal proc macro for xrpl-common-stdlib - use xrpl-common-stdlib instead"
 license.workspace = true

--- a/xrpl-stdlib-test-utils/Cargo.toml
+++ b/xrpl-stdlib-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-stdlib-test-utils"
-version = "0.9.0"
+version = "0.10.0-dev"
 edition = "2024"
 description = "Test harness for XRPL WebAssembly smart contracts: MockHostBindings plus escrow scenario builders"
 license.workspace = true
@@ -16,7 +16,7 @@ include = ["src/", "README.md"]
 # dependency because this crate *is* the harness — consumers gate it out of WASM builds by declaring
 # this crate under `[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]` instead.
 # Both `version` and `path` are required — see xrpl-escrow-stdlib/Cargo.toml for why.
-xrpl-common-stdlib = { version = "0.9.0", path = "../xrpl-common-stdlib", features = [
+xrpl-common-stdlib = { version = "0.10.0-dev", path = "../xrpl-common-stdlib", features = [
   "test-host-bindings",
 ] }
 mockall.workspace = true


### PR DESCRIPTION
## High Level Overview of Change

Moves all four published crates from `0.9.0` to `0.10.0-dev`, so `main` no longer carries a released
version number.

### Context of Change

`0.9.0` is now the published release, but `main` still claims that version — so any build off `main`
from here on would report `0.9.0` while containing unreleased changes. `0.10.0-dev` is a semver
prerelease of `0.10.0`, ordering `0.9.0 < 0.10.0-dev < 0.10.0`, which makes any in-between build
self-identifying. Same idea as rippled's `-b1` suffixes or Maven's `-SNAPSHOT`.

Note that the `version` key on each in-workspace dependency carries the full `0.10.0-dev` string
rather than a plain `0.10.0`. Cargo treats prereleases as opt-in, so a bare `^0.10.0` requirement
does **not** match a `0.10.0-dev` package and resolution fails outright:

```
error: failed to select a version for the requirement `xrpl-macros = "^0.10.0"`
candidate versions found which didn't match: 0.10.0-dev
if you are looking for the prerelease package it needs to be specified explicitly
```

That same opt-in rule means a prerelease is invisible to `cargo add`, so this version is not intended
to be published — a consumer would have to request it by exact version to get it at all.

This implies one addition to the release flow: a release PR flips `-dev` off to publish, then `main`
is immediately bumped to the next `-dev`. `CONTRIBUTING.md`'s "Release Process" predates this
convention and does not yet describe that final step.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (added tests for existing code, or tests for the new feature in this PR)
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [x] Release

## Test Plan

Version numbers only — no source changes. All three workspaces resolve at `0.10.0-dev` (`cargo
metadata` in `/`, `examples/`, and `e2e-tests/`), and `cargo test --workspace` plus
`./scripts/clippy.sh` pass.

## Future Tasks

Add the post-release `-dev` bump as an explicit step in `CONTRIBUTING.md`'s "Release Process" if this
convention is adopted.
