### PR TITLE
chore: Mark e2e-test crates publish = false

### DIFF
--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 resolver = "2"
+# Probe/test crates only; each member sets `publish = false`.
 members = [
     "float_tests",
     "gas_benchmark",

--- a/e2e-tests/float_tests/Cargo.toml
+++ b/e2e-tests/float_tests/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.8.0"
 edition = "2024"
 description = "Test suite for XRPL floating-point operations including arithmetic, comparison, and mathematical functions"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/e2e-tests/float_tests/Cargo.toml
+++ b/e2e-tests/float_tests/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.8.0"
 edition = "2024"
 description = "Test suite for XRPL floating-point operations including arithmetic, comparison, and mathematical functions"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/e2e-tests/gas_benchmark/Cargo.toml
+++ b/e2e-tests/gas_benchmark/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.8.0"
 edition = "2024"
 description = "Gas benchmark contract for measuring optimization impact"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/e2e-tests/gas_benchmark/Cargo.toml
+++ b/e2e-tests/gas_benchmark/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.8.0"
 edition = "2024"
 description = "Gas benchmark contract for measuring optimization impact"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/e2e-tests/host_functions_test/Cargo.toml
+++ b/e2e-tests/host_functions_test/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.8.0"
 edition = "2024"
 description = "End-to-end test suite for all 26 WASM host functions across 7 categories with comprehensive error handling"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/e2e-tests/host_functions_test/Cargo.toml
+++ b/e2e-tests/host_functions_test/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.8.0"
 edition = "2024"
 description = "End-to-end test suite for all 26 WASM host functions across 7 categories with comprehensive error handling"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/e2e-tests/keylet_exists/Cargo.toml
+++ b/e2e-tests/keylet_exists/Cargo.toml
@@ -4,6 +4,8 @@ name = "keylet_exists"
 version = "0.1.0"
 description = "Smart Escrow example demonstrating ledger entry ID generation and ledger object existence verification"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/e2e-tests/keylet_exists/Cargo.toml
+++ b/e2e-tests/keylet_exists/Cargo.toml
@@ -4,7 +4,6 @@ name = "keylet_exists"
 version = "0.1.0"
 description = "Smart Escrow example demonstrating ledger entry ID generation and ledger object existence verification"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/e2e-tests/test_utils/Cargo.toml
+++ b/e2e-tests/test_utils/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.8.0"
 edition = "2024"
 description = "Test utilities for XRPL WASM e2e tests"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/e2e-tests/trace_escrow_account/Cargo.toml
+++ b/e2e-tests/trace_escrow_account/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.8.0"
 edition = "2024"
 description = "End-to-end test that validates AccountRoot ledger object field access and tracing functionality"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/e2e-tests/trace_escrow_account/Cargo.toml
+++ b/e2e-tests/trace_escrow_account/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.8.0"
 edition = "2024"
 description = "End-to-end test that validates AccountRoot ledger object field access and tracing functionality"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/e2e-tests/trace_escrow_finish/Cargo.toml
+++ b/e2e-tests/trace_escrow_finish/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.8.0"
 edition = "2024"
 description = "End-to-end test that validates EscrowFinish transaction field access and tracing functionality"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/e2e-tests/trace_escrow_finish/Cargo.toml
+++ b/e2e-tests/trace_escrow_finish/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.8.0"
 edition = "2024"
 description = "End-to-end test that validates EscrowFinish transaction field access and tracing functionality"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/e2e-tests/trace_escrow_ledger_object/Cargo.toml
+++ b/e2e-tests/trace_escrow_ledger_object/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.8.0"
 edition = "2024"
 description = "End-to-end test that validates Escrow ledger object field access and tracing functionality"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/e2e-tests/trace_escrow_ledger_object/Cargo.toml
+++ b/e2e-tests/trace_escrow_ledger_object/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.8.0"
 edition = "2024"
 description = "End-to-end test that validates Escrow ledger object field access and tracing functionality"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 resolver = "2"
+# Example contracts only; each member sets `publish = false`.
 members = [
     "smart-escrows/atomic_swap/atomic_swap1",
     "smart-escrows/atomic_swap/atomic_swap2",

--- a/examples/smart-escrows/atomic_swap/atomic_swap1/Cargo.toml
+++ b/examples/smart-escrows/atomic_swap/atomic_swap1/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that implements atomic swaps using memo-based counterpart escrow validation"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 
 [lib]

--- a/examples/smart-escrows/atomic_swap/atomic_swap1/Cargo.toml
+++ b/examples/smart-escrows/atomic_swap/atomic_swap1/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that implements atomic swaps using memo-based counterpart escrow validation"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 

--- a/examples/smart-escrows/atomic_swap/atomic_swap2/Cargo.toml
+++ b/examples/smart-escrows/atomic_swap/atomic_swap2/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that implements atomic swaps using data field-based two-phase execution"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 
 [lib]

--- a/examples/smart-escrows/atomic_swap/atomic_swap2/Cargo.toml
+++ b/examples/smart-escrows/atomic_swap/atomic_swap2/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that implements atomic swaps using data field-based two-phase execution"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 

--- a/examples/smart-escrows/freelancer_escrow/Cargo.toml
+++ b/examples/smart-escrows/freelancer_escrow/Cargo.toml
@@ -2,6 +2,8 @@
 name = "freelancer_escrow"
 version = "0.1.0"
 edition = "2024"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/smart-escrows/freelancer_escrow/Cargo.toml
+++ b/examples/smart-escrows/freelancer_escrow/Cargo.toml
@@ -2,7 +2,6 @@
 name = "freelancer_escrow"
 version = "0.1.0"
 edition = "2024"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/examples/smart-escrows/hello_world/Cargo.toml
+++ b/examples/smart-escrows/hello_world/Cargo.toml
@@ -4,6 +4,8 @@ version = "1.0.0"
 edition = "2024"
 description = "A Smart Escrow that simply emits 'Hello World' into the trace log and then releases the escrow."
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/smart-escrows/hello_world/Cargo.toml
+++ b/examples/smart-escrows/hello_world/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2024"
 description = "A Smart Escrow that simply emits 'Hello World' into the trace log and then releases the escrow."
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/examples/smart-escrows/kyc/Cargo.toml
+++ b/examples/smart-escrows/kyc/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.0.1"
 edition = "2024"
 description = "Smart Escrow example that unlocks based on the presence of specific KYC credentials on the XRPL"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/smart-escrows/kyc/Cargo.toml
+++ b/examples/smart-escrows/kyc/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 edition = "2024"
 description = "Smart Escrow example that unlocks based on the presence of specific KYC credentials on the XRPL"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 [lib]

--- a/examples/smart-escrows/ledger_sqn/Cargo.toml
+++ b/examples/smart-escrows/ledger_sqn/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that unlocks when the ledger sequence number reaches a minimum threshold"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 
 [lib]

--- a/examples/smart-escrows/ledger_sqn/Cargo.toml
+++ b/examples/smart-escrows/ledger_sqn/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that unlocks when the ledger sequence number reaches a minimum threshold"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 

--- a/examples/smart-escrows/nft_owner/Cargo.toml
+++ b/examples/smart-escrows/nft_owner/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that unlocks when the destination account owns a specific NFT provided via memo"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 
 [lib]

--- a/examples/smart-escrows/nft_owner/Cargo.toml
+++ b/examples/smart-escrows/nft_owner/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that unlocks when the destination account owns a specific NFT provided via memo"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 

--- a/examples/smart-escrows/notary/Cargo.toml
+++ b/examples/smart-escrows/notary/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that unlocks when the EscrowFinish transaction is signed by a designated notary account"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 
 [lib]

--- a/examples/smart-escrows/notary/Cargo.toml
+++ b/examples/smart-escrows/notary/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that unlocks when the EscrowFinish transaction is signed by a designated notary account"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 

--- a/examples/smart-escrows/oracle/Cargo.toml
+++ b/examples/smart-escrows/oracle/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that unlocks when oracle price data meets specified threshold conditions"
 license = "ISC"
+# Do not publish this crate
+publish = false
 
 
 [lib]

--- a/examples/smart-escrows/oracle/Cargo.toml
+++ b/examples/smart-escrows/oracle/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2024"
 description = "Smart Escrow example that unlocks when oracle price data meets specified threshold conditions"
 license = "ISC"
-# Do not publish this crate
 publish = false
 
 


### PR DESCRIPTION
## Summary
- Sets `publish = false` on every `e2e-tests` package and `example` that was still publishable, matching `test_utils`.
- Notes on the virtual workspace that these are probe crates, not crates.io packages.

Fixes #115

## Test plan
- [x] `cargo metadata --manifest-path e2e-tests/Cargo.toml --format-version 1 --no-deps` — all 8 workspace members have `"publish": []` (`publish = false`)
- [ ] Confirm `cargo publish` is not part of e2e CI