### PR TITLE
ci: Add advisory-only cargo-deny check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,20 @@ jobs:
       - name: Run host function audit
         run: ./scripts/host-function-audit.sh
 
+  # Advisory-only experiment (issue #126). Left out of run-all.sh so contributors
+  # without cargo-deny can still run the local suite. continue-on-error: the first
+  # CI run is informational; flip this job to required after it stays clean.
+  cargo_deny:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+      - name: Check RustSec advisories
+        run: ./scripts/cargo-deny.sh
+
   validate_ui:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ DEVNET=true ./scripts/run-tests.sh                         # run against wss://w
 ./scripts/generate-ledger-objects.sh
 ```
 
-Other scripts not part of the primary workflow above: `scripts/benchmark-gas.sh`, `scripts/check-wasm-exports.sh`, `scripts/docs.sh` (builds and deploys the GitHub Pages docs/UI site), `scripts/host-function-audit.sh` (see below), `scripts/run-markdown.sh`, `scripts/validate-ui.sh`.
+Other scripts not part of the primary workflow above: `scripts/benchmark-gas.sh`, `scripts/check-wasm-exports.sh`, `scripts/docs.sh` (builds and deploys the GitHub Pages docs/UI site), `scripts/host-function-audit.sh` (see below), `scripts/run-markdown.sh`, `scripts/validate-ui.sh`, `scripts/cargo-deny.sh` (RustSec advisories on the library workspace; advisory-only in CI until the first clean run).
 
 Pre-commit hooks (`.pre-commit-config.yaml`) run `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -Dclippy::all` on staged Rust files, plus prettier with `--no-semi --tab-width 2` for JS/MD/YAML.
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,41 @@
+# cargo-deny configuration for the published library workspace.
+#
+# Issue #126 is an advisory-only experiment: CI and `scripts/cargo-deny.sh` run
+# `cargo deny check advisories` against the root Cargo.toml. examples/ and
+# e2e-tests/ are unpublished cdylibs that only path-depend on these crates.
+# licenses/bans/sources are filled in so a later `cargo deny check` (all lint
+# types) has a starting policy, but they are not enforced yet.
+
+[graph]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "wasm32v1-none",
+]
+all-features = true
+
+[advisories]
+yanked = "warn"
+
+[licenses]
+confidence-threshold = 0.8
+allow = [
+    "ISC",
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Unicode-3.0",
+    "Zlib",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,6 +38,7 @@ You can also run individual test suites:
 - **`run-markdown.sh`** - Execute bash code blocks in Markdown files
 - **`run-tests.sh`** - Run integration tests for examples and end-to-end tests
 - **`host-function-audit.sh`** - Audit host functions against XRPLd (requires Node.js)
+- **`cargo-deny.sh`** - Check RustSec advisories on the library workspace (requires `cargo-deny`)
 - **`benchmark-gas.sh`** - Measure and compare gas costs of optimized helper functions
 - **`generate-sfields.sh`** - Generate type-safe SField constants from rippled source (requires Node.js)
 
@@ -67,6 +68,9 @@ You can also run individual test suites:
 
 # Generate SField constants from rippled source
 ./scripts/generate-sfields.sh
+
+# Check RustSec advisories (install cargo-deny first)
+./scripts/cargo-deny.sh
 ```
 
 ## Environment Variables
@@ -167,6 +171,7 @@ setup.sh (run first)
     └── ../build.sh (dependency)
 ├── fmt.sh
 ├── host-function-audit.sh (requires Node.js)
+├── cargo-deny.sh (requires cargo-deny; library workspace only; not in run-all.sh while advisory-only)
 └── run-markdown.sh
 ```
 

--- a/scripts/cargo-deny.sh
+++ b/scripts/cargo-deny.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# cargo-deny advisory check
+# Mirrors the cargo_deny job from GitHub Actions.
+#
+# Advisory-only experiment (issue #126): checks RustSec advisories on the
+# published library workspace (root Cargo.toml). examples/ and e2e-tests/ only
+# path-depend on those crates, so they are not checked separately.
+# licenses/bans/sources in deny.toml are not enforced yet.
+#
+# Usage:
+#   ./scripts/cargo-deny.sh            # fail if the library workspace has advisories
+#   ./scripts/cargo-deny.sh --warn-only  # print findings, always exit 0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+WARN_ONLY=0
+if [[ "${1:-}" == "--warn-only" ]]; then
+    WARN_ONLY=1
+elif [[ "${1:-}" != "" ]]; then
+    echo "Usage: $0 [--warn-only]"
+    exit 2
+fi
+
+if ! command -v cargo-deny &> /dev/null; then
+    echo "❌ cargo-deny is not installed."
+    echo "   Install with: cargo install cargo-deny --locked"
+    exit 1
+fi
+
+echo "🔧 Running cargo-deny advisory check on the library workspace..."
+echo "   $(cargo deny --version 2>/dev/null || true)"
+
+status=0
+if cargo deny --config "$REPO_ROOT/deny.toml" check advisories; then
+    echo "✅ cargo-deny advisory check passed"
+else
+    echo "❌ cargo-deny advisory check failed"
+    status=1
+fi
+
+if [[ "$WARN_ONLY" -eq 1 && "$status" -ne 0 ]]; then
+    echo "⚠️  cargo-deny reported advisories, but --warn-only is set (issue #126 experiment)."
+    exit 0
+fi
+
+exit "$status"


### PR DESCRIPTION
## High Level Overview of Change

Adds an advisory-only `cargo-deny` check for the published library workspace (`Fixes #126`).

### Context of Change

Issue #126 asked for a first-pass `cargo-deny` experiment: `deny.toml` plus a CI/script check, advisories only, without failing the whole suite on the first run.

The check targets the root workspace (`xrpl-common-stdlib`, `xrpl-macros`, `xrpl-escrow-stdlib`, `xrpl-stdlib-test-utils`). `examples/` and `e2e-tests/` are unpublished cdylibs that only path-depend on those crates, so they are not scanned separately.

A local `./scripts/cargo-deny.sh` run was clean (`advisories ok`). The CI job uses `continue-on-error: true` so the first GitHub run stays informational; it is also left out of `run-all.sh` so contributors do not need `cargo-deny` installed.

### Type of Change

- [x] Build / CI / tooling change

## Test Plan

- [x] `./scripts/cargo-deny.sh` — `advisories ok` on the library workspace
- [ ] Confirm the `cargo_deny` job runs on this PR (informational; `continue-on-error`)

## Future Tasks

- Flip `continue-on-error` off (and optionally add the script to `run-all.sh`) after CI stays clean
- Expand from `check advisories` to licenses/bans/sources when ready