### PR TITLE
ci: Use Docker locally, by default, for e2e-tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,31 +165,19 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Run docker in background
-        run: |
-          docker run --detach --rm -p 5005:5005 -p 6006:6006 --volume "${{ github.workspace }}/.ci-config/":"/etc/xrpld/" --name xrpld-service --health-cmd="xrpld server_info || exit 1" --health-interval=5s --health-retries=10 --health-timeout=2s --entrypoint bash ${{ env.XRPLD_DOCKER_IMAGE }} -c "xrpld -a"
-
-      - name: Wait for xrpld to be healthy
-        run: |
-          echo "Waiting for xrpld container to be healthy..."
-          timeout 120 bash -c 'until docker inspect --format="{{.State.Health.Status}}" xrpld-service 2>/dev/null | grep -q "healthy"; do echo "Still waiting..."; docker logs --tail 10 xrpld-service 2>&1 || true; sleep 5; done'
-          echo "xrpld is healthy!"
-          docker logs xrpld-service
+      - name: Start rippled in Docker
+        run: ./scripts/docker-rippled.sh start
 
       - name: Run end-to-end tests
         run: ./scripts/run-tests.sh
 
       - name: Show docker logs on failure
         if: failure()
-        run: |
-          echo "=== Docker container logs ==="
-          docker logs xrpld-service 2>&1 || echo "Could not get logs"
-          echo "=== Docker container status ==="
-          docker inspect xrpld-service 2>&1 || echo "Could not inspect container"
+        run: ./scripts/docker-rippled.sh logs
 
       - name: Stop docker container
         if: always()
-        run: docker stop xrpld-service
+        run: ./scripts/docker-rippled.sh stop
 
   coverage:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,21 +125,24 @@ canonically-ordered account pair produce the same result either way.
 | **Local Node**  | `ws://localhost:6006`                    | Development (default) |
 | **WASM Devnet** | `wss://wasm.devnet.rippletest.net:51233` | Integration testing   |
 
-`./scripts/run-tests.sh` (and therefore `./scripts/run-all.sh`) targets the local node by default, and manages it for you: it starts a rippled node in Docker via `./scripts/docker-rippled.sh`, pinned to the exact `XRPLD_DOCKER_IMAGE` tag CI uses (see `.github/workflows/test.yml`). This matters because the npm packages in `package.json` (`xrpl`, `ripple-binary-codec`) are built against a specific rippled field/transaction definition set — testing against a rippled build that has drifted from that pin (e.g. a locally-built binary from a different branch or commit) can fail with cryptic errors like `Field 'X' found in disallowed location`, because field codes shifted underneath the JS encoder.
+`./scripts/run-tests.sh` (and therefore `./scripts/run-all.sh`) targets the local node by default, and manages it for you: it starts a rippled node in Docker via `./scripts/docker-rippled.sh`, pinned to the exact `XRPLD_DOCKER_IMAGE` tag CI uses (see `.github/workflows/test.yml` — the single place that tag is defined; `docker-rippled.sh` reads it from there rather than duplicating it). This matters because the npm packages in `package.json` (`xrpl`, `ripple-binary-codec`) are built against a specific rippled field/transaction definition set — testing against a rippled build that has drifted from that pin (e.g. a locally-built binary from a different branch or commit) can fail with cryptic errors like `Field 'X' found in disallowed location`, because field codes shifted underneath the JS encoder.
+
+Before starting Docker, `docker-rippled.sh` checks whether something is already listening on `ws://localhost:6006` (a container from a previous run, a rippled you started yourself, a native build) and reuses it instead — Docker isn't required at all if you already have rippled running.
 
 Override the default with an environment variable:
 
 ```shell
-./scripts/run-tests.sh                    # default: Docker rippled pinned to CI's image
-NO_DOCKER=true ./scripts/run-tests.sh     # use a rippled you're already running yourself
+./scripts/run-tests.sh                    # default: reuses a running rippled, else starts Docker pinned to CI's image
+NO_DOCKER=true ./scripts/run-tests.sh     # force-skip Docker; use a rippled you're already running yourself
 DEVNET=true ./scripts/run-tests.sh        # use WASM Devnet instead
 ```
 
 The Docker container (`xrpld-service`) is left running between invocations for faster iteration. Manage it directly with:
 
 ```shell
-./scripts/docker-rippled.sh start   # idempotent - reuses a healthy container if one exists
+./scripts/docker-rippled.sh start   # idempotent - reuses a healthy container, or any rippled already on port 6006
 ./scripts/docker-rippled.sh status
+./scripts/docker-rippled.sh logs    # container logs + inspect output, e.g. after a failure
 ./scripts/docker-rippled.sh stop
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,10 +120,28 @@ canonically-ordered account pair produce the same result either way.
 
 ### Test Networks
 
-| Network         | Endpoint                                 | Purpose             |
-| --------------- | ---------------------------------------- | ------------------- |
-| **WASM Devnet** | `wss://wasm.devnet.rippletest.net:51233` | Integration testing |
-| **Local Node**  | `ws://localhost:6006`                    | Development         |
+| Network         | Endpoint                                 | Purpose               |
+| --------------- | ---------------------------------------- | --------------------- |
+| **Local Node**  | `ws://localhost:6006`                    | Development (default) |
+| **WASM Devnet** | `wss://wasm.devnet.rippletest.net:51233` | Integration testing   |
+
+`./scripts/run-tests.sh` (and therefore `./scripts/run-all.sh`) targets the local node by default, and manages it for you: it starts a rippled node in Docker via `./scripts/docker-rippled.sh`, pinned to the exact `XRPLD_DOCKER_IMAGE` tag CI uses (see `.github/workflows/test.yml`). This matters because the npm packages in `package.json` (`xrpl`, `ripple-binary-codec`) are built against a specific rippled field/transaction definition set — testing against a rippled build that has drifted from that pin (e.g. a locally-built binary from a different branch or commit) can fail with cryptic errors like `Field 'X' found in disallowed location`, because field codes shifted underneath the JS encoder.
+
+Override the default with an environment variable:
+
+```shell
+./scripts/run-tests.sh                    # default: Docker rippled pinned to CI's image
+NO_DOCKER=true ./scripts/run-tests.sh     # use a rippled you're already running yourself
+DEVNET=true ./scripts/run-tests.sh        # use WASM Devnet instead
+```
+
+The Docker container (`xrpld-service`) is left running between invocations for faster iteration. Manage it directly with:
+
+```shell
+./scripts/docker-rippled.sh start   # idempotent - reuses a healthy container if one exists
+./scripts/docker-rippled.sh status
+./scripts/docker-rippled.sh stop
+```
 
 ### Debugging and Development
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ Each example under `examples/smart-escrows/` has an integration test that submit
 ./scripts/run-tests.sh examples/smart-escrows/hello_world   # a single example
 ```
 
-By default this starts a local rippled in Docker, pinned to the exact image [CI uses](.github/workflows/test.yml), so your results match CI without any manual node setup. Override with:
+If rippled is already running on `ws://localhost:6006` (your own instance, or a container left over from a previous run), that's reused automatically — no Docker needed. Otherwise this starts a local rippled in Docker, pinned to the exact image [CI uses](.github/workflows/test.yml), so your results match CI without any manual node setup. Override with:
 
-| Variable         | Effect                                                                              |
-| ---------------- | ----------------------------------------------------------------------------------- |
-| `DEVNET=true`    | Test against WASM Devnet (`wss://wasm.devnet.rippletest.net:51233`) instead         |
-| `NO_DOCKER=true` | Skip Docker; use a rippled you're already running yourself on `ws://localhost:6006` |
+| Variable         | Effect                                                                                    |
+| ---------------- | ----------------------------------------------------------------------------------------- |
+| `DEVNET=true`    | Test against WASM Devnet (`wss://wasm.devnet.rippletest.net:51233`) instead               |
+| `NO_DOCKER=true` | Force-skip Docker; use a rippled you're already running yourself on `ws://localhost:6006` |
 
 The Docker node is left running across test runs for speed; stop it with `./scripts/docker-rippled.sh stop` when you're done. See [`scripts/README.md`](./scripts/README.md) and [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more on the local dev/test scripts.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ fn releases_above_ten_xrp() {
 
 Anything you leave unset gets a default. See [the crate's README](https://github.com/ripple/xrpl-wasm-stdlib/tree/main/xrpl-stdlib-test-utils) for the full builder.
 
+### Running the examples' integration tests
+
+Each example under `examples/smart-escrows/` has an integration test that submits real transactions to a rippled node:
+
+```shell
+./scripts/run-tests.sh                                     # all examples + e2e contracts
+./scripts/run-tests.sh examples/smart-escrows/hello_world   # a single example
+```
+
+By default this starts a local rippled in Docker, pinned to the exact image [CI uses](.github/workflows/test.yml), so your results match CI without any manual node setup. Override with:
+
+| Variable         | Effect                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------- |
+| `DEVNET=true`    | Test against WASM Devnet (`wss://wasm.devnet.rippletest.net:51233`) instead         |
+| `NO_DOCKER=true` | Skip Docker; use a rippled you're already running yourself on `ws://localhost:6006` |
+
+The Docker node is left running across test runs for speed; stop it with `./scripts/docker-rippled.sh stop` when you're done. See [`scripts/README.md`](./scripts/README.md) and [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more on the local dev/test scripts.
+
 ## Documentation
 
 | Section                                                                                                       | Description                                     |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,8 +36,8 @@ You can also run individual test suites:
 - **`clippy.sh`** - Run Clippy linting on both native and WASM workspaces
 - **`fmt.sh`** - Check Rust code formatting
 - **`run-markdown.sh`** - Execute bash code blocks in Markdown files
-- **`run-tests.sh`** - Run integration tests for examples and end-to-end tests (starts a local Docker rippled by default; see below)
-- **`docker-rippled.sh`** - Start/stop/check a local rippled node in Docker, pinned to the same image CI uses (`start`/`stop`/`status`)
+- **`run-tests.sh`** - Run integration tests for examples and end-to-end tests (reuses a running rippled, else starts one in Docker; see below)
+- **`docker-rippled.sh`** - Start/stop/check a local rippled node in Docker, pinned to the same image CI uses; also used by CI itself, so this is the only place the container's `docker run`/health-check/logs logic lives (`start`/`stop`/`status`/`logs`)
 - **`host-function-audit.sh`** - Audit host functions against XRPLd (requires Node.js)
 - **`benchmark-gas.sh`** - Measure and compare gas costs of optimized helper functions
 - **`generate-sfields.sh`** - Generate type-safe SField constants from rippled source (requires Node.js)
@@ -60,7 +60,7 @@ You can also run individual test suites:
 # Run only clippy checks
 ./scripts/clippy.sh
 
-# Run only integration tests (auto-starts a local Docker rippled)
+# Run only integration tests (reuses a running rippled, else auto-starts one in Docker)
 ./scripts/run-tests.sh
 
 # Run integration tests against a rippled you're already running yourself
@@ -70,8 +70,9 @@ NO_DOCKER=true ./scripts/run-tests.sh
 DEVNET=true ./scripts/run-tests.sh
 
 # Manage the local Docker rippled directly
-./scripts/docker-rippled.sh start
+./scripts/docker-rippled.sh start   # no-op if rippled is already reachable on port 6006
 ./scripts/docker-rippled.sh status
+./scripts/docker-rippled.sh logs
 ./scripts/docker-rippled.sh stop
 
 # Run gas benchmarks (requires local rippled instance)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,8 @@ You can also run individual test suites:
 - **`clippy.sh`** - Run Clippy linting on both native and WASM workspaces
 - **`fmt.sh`** - Check Rust code formatting
 - **`run-markdown.sh`** - Execute bash code blocks in Markdown files
-- **`run-tests.sh`** - Run integration tests for examples and end-to-end tests
+- **`run-tests.sh`** - Run integration tests for examples and end-to-end tests (starts a local Docker rippled by default; see below)
+- **`docker-rippled.sh`** - Start/stop/check a local rippled node in Docker, pinned to the same image CI uses (`start`/`stop`/`status`)
 - **`host-function-audit.sh`** - Audit host functions against XRPLd (requires Node.js)
 - **`benchmark-gas.sh`** - Measure and compare gas costs of optimized helper functions
 - **`generate-sfields.sh`** - Generate type-safe SField constants from rippled source (requires Node.js)
@@ -59,8 +60,19 @@ You can also run individual test suites:
 # Run only clippy checks
 ./scripts/clippy.sh
 
-# Run only integration tests
+# Run only integration tests (auto-starts a local Docker rippled)
 ./scripts/run-tests.sh
+
+# Run integration tests against a rippled you're already running yourself
+NO_DOCKER=true ./scripts/run-tests.sh
+
+# Run integration tests against WASM Devnet instead
+DEVNET=true ./scripts/run-tests.sh
+
+# Manage the local Docker rippled directly
+./scripts/docker-rippled.sh start
+./scripts/docker-rippled.sh status
+./scripts/docker-rippled.sh stop
 
 # Run gas benchmarks (requires local rippled instance)
 ./scripts/benchmark-gas.sh
@@ -78,6 +90,11 @@ export RUSTFLAGS="-Dwarnings"
 ```
 
 This matches the CI environment and ensures warnings are treated as errors.
+
+`run-tests.sh` additionally respects:
+
+- **`DEVNET=true`** - test against WASM Devnet instead of a local node
+- **`NO_DOCKER=true`** - skip the automatic Docker rippled and test against a rippled you're already running yourself on `ws://localhost:6006`
 
 ## Gas Benchmark Script
 
@@ -141,7 +158,8 @@ To add more custom mappings, edit the `customFieldTypes` object in `tools/genera
 
 - **Rust**: Stable toolchain (installed automatically by `setup.sh`)
 - **Pre-commit**: For running pre-commit hooks (installed by `setup.sh`)
-- **Node.js**: Required for host function audit and gas benchmark scripts
+- **Node.js**: Required for host function audit, gas benchmark, and integration test scripts
+- **Docker**: Required for `run-tests.sh`'s default local rippled (skip with `NO_DOCKER=true` or `DEVNET=true`)
 
 ## GitHub Actions Compatibility
 
@@ -154,6 +172,7 @@ Actions workflows, ensuring perfect consistency between local and CI environment
 - **Pre-commit not found**: Run `./scripts/setup.sh` to install dependencies
 - **Node.js required**: Install Node.js for the host function audit, or skip that script
 - **WASM target missing**: The scripts automatically install the `wasm32v1-none` target
+- **Docker not found / daemon not reachable**: Install/start Docker, or set `NO_DOCKER=true` (use your own local rippled) or `DEVNET=true` (use WASM Devnet)
 
 ## Script Dependencies
 

--- a/scripts/docker-rippled.sh
+++ b/scripts/docker-rippled.sh
@@ -11,9 +11,10 @@ cd "$REPO_ROOT"
 
 CONTAINER_NAME="xrpld-service"
 WORKFLOW_FILE=".github/workflows/test.yml"
+RIPPLED_WS_PORT=6006
 
 usage() {
-    echo "Usage: $0 {start|stop|status}"
+    echo "Usage: $0 {start|stop|status|logs}"
     exit 1
 }
 
@@ -38,13 +39,25 @@ is_healthy() {
     docker inspect --format="{{.State.Health.Status}}" "$CONTAINER_NAME" 2>/dev/null | grep -q "healthy"
 }
 
-start() {
-    require_docker
+# True if something is already accepting connections on the rippled WS port,
+# whether that's our own container, a manually-run rippled, or a native build.
+# Checked with a bare TCP dial (bash's /dev/tcp) so this works even without Docker installed.
+is_port_open() {
+    (: < "/dev/tcp/127.0.0.1/$RIPPLED_WS_PORT") 2>/dev/null
+}
 
+start() {
     if is_healthy; then
         echo "✅ $CONTAINER_NAME is already running and healthy."
         return 0
     fi
+
+    if is_port_open; then
+        echo "✅ Something is already listening on ws://localhost:$RIPPLED_WS_PORT - assuming rippled is already running; skipping Docker."
+        return 0
+    fi
+
+    require_docker
 
     # A stopped/unhealthy container from a previous run shouldn't block a fresh start.
     docker rm -f "$CONTAINER_NAME" &> /dev/null || true
@@ -93,9 +106,17 @@ status() {
     fi
 }
 
+logs() {
+    echo "=== Docker container logs ==="
+    docker logs "$CONTAINER_NAME" 2>&1 || echo "Could not get logs"
+    echo "=== Docker container status ==="
+    docker inspect "$CONTAINER_NAME" 2>&1 || echo "Could not inspect container"
+}
+
 case "${1:-}" in
     start) start ;;
     stop) stop ;;
     status) status ;;
+    logs) logs ;;
     *) usage ;;
 esac

--- a/scripts/docker-rippled.sh
+++ b/scripts/docker-rippled.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Start/stop a local rippled (xrpld) node in Docker, pinned to the same image CI uses.
+# This keeps local integration tests in sync with the field/transaction definitions
+# that the npm packages in package.json were generated against.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+CONTAINER_NAME="xrpld-service"
+WORKFLOW_FILE=".github/workflows/test.yml"
+
+usage() {
+    echo "Usage: $0 {start|stop|status}"
+    exit 1
+}
+
+require_docker() {
+    if ! command -v docker &> /dev/null; then
+        echo "❌ Docker not found. Install Docker, or set NO_DOCKER=true / DEVNET=true to skip it." >&2
+        exit 1
+    fi
+    if ! docker info &> /dev/null; then
+        echo "❌ Docker daemon not reachable. Start Docker Desktop (or dockerd), or set NO_DOCKER=true / DEVNET=true to skip it." >&2
+        exit 1
+    fi
+}
+
+get_image() {
+    # Single source of truth: the image tag CI pins in test.yml. Reading it here
+    # means this script can never drift from what CI actually verified against.
+    grep -m1 'XRPLD_DOCKER_IMAGE:' "$WORKFLOW_FILE" | sed -E 's/^[[:space:]]*XRPLD_DOCKER_IMAGE:[[:space:]]*//'
+}
+
+is_healthy() {
+    docker inspect --format="{{.State.Health.Status}}" "$CONTAINER_NAME" 2>/dev/null | grep -q "healthy"
+}
+
+start() {
+    require_docker
+
+    if is_healthy; then
+        echo "✅ $CONTAINER_NAME is already running and healthy."
+        return 0
+    fi
+
+    # A stopped/unhealthy container from a previous run shouldn't block a fresh start.
+    docker rm -f "$CONTAINER_NAME" &> /dev/null || true
+
+    local image
+    image="$(get_image)"
+    if [[ -z "$image" ]]; then
+        echo "❌ Could not read XRPLD_DOCKER_IMAGE from $WORKFLOW_FILE" >&2
+        exit 1
+    fi
+
+    echo "🐳 Starting $CONTAINER_NAME from $image ..."
+    docker run --detach --rm \
+        -p 5005:5005 -p 6006:6006 \
+        --volume "$REPO_ROOT/.ci-config/:/etc/xrpld/" \
+        --name "$CONTAINER_NAME" \
+        --health-cmd="xrpld server_info || exit 1" \
+        --health-interval=5s --health-retries=10 --health-timeout=2s \
+        --entrypoint bash "$image" -c "xrpld -a" > /dev/null
+
+    echo "⏳ Waiting for $CONTAINER_NAME to be healthy..."
+    # Avoid GNU coreutils' `timeout`, which macOS doesn't ship by default.
+    local elapsed=0
+    until is_healthy; do
+        if (( elapsed >= 120 )); then
+            echo "❌ $CONTAINER_NAME did not become healthy in time." >&2
+            docker logs --tail 50 "$CONTAINER_NAME" 2>&1 || true
+            exit 1
+        fi
+        sleep 5
+        elapsed=$(( elapsed + 5 ))
+    done
+    echo "✅ $CONTAINER_NAME is healthy."
+}
+
+stop() {
+    docker stop "$CONTAINER_NAME" &> /dev/null || true
+    echo "🛑 $CONTAINER_NAME stopped."
+}
+
+status() {
+    if is_healthy; then
+        echo "✅ $CONTAINER_NAME is running and healthy."
+    else
+        echo "⚫ $CONTAINER_NAME is not running."
+    fi
+}
+
+case "${1:-}" in
+    start) start ;;
+    stop) stop ;;
+    status) status ;;
+    *) usage ;;
+esac

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -17,7 +17,7 @@ npm ls --silent > /dev/null 2>&1 || npm ci
 # By default, tests run against a local rippled. scripts/docker-rippled.sh reuses one
 # that's already running on ws://localhost:6006, or else starts one in Docker, pinned to
 # the same image CI uses. Override with:
-if [[ "${DEVNET:-}" == "true" ]]; then
+#   DEVNET=true      - test against wss://wasm.devnet.rippletest.net:51233 instead
 #   NO_DOCKER=true   - force-skip Docker; test against a rippled you're already running yourself
 if [[ "${DEVNET:-}" == "true" ]]; then
     echo "🌐 DEVNET set - skipping local Docker rippled."

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -17,7 +17,7 @@ npm ls --silent > /dev/null 2>&1 || npm ci
 # By default, tests run against a local rippled. scripts/docker-rippled.sh reuses one
 # that's already running on ws://localhost:6006, or else starts one in Docker, pinned to
 # the same image CI uses. Override with:
-#   DEVNET=true      - test against wss://wasm.devnet.rippletest.net:51233 instead
+if [[ "${DEVNET:-}" == "true" ]]; then
 #   NO_DOCKER=true   - force-skip Docker; test against a rippled you're already running yourself
 if [[ "${DEVNET:-}" == "true" || -n "${DEVNET:-}" ]]; then
     echo "🌐 DEVNET set - skipping local Docker rippled."

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -19,7 +19,7 @@ npm ls --silent > /dev/null 2>&1 || npm ci
 # the same image CI uses. Override with:
 if [[ "${DEVNET:-}" == "true" ]]; then
 #   NO_DOCKER=true   - force-skip Docker; test against a rippled you're already running yourself
-if [[ "${DEVNET:-}" == "true" || -n "${DEVNET:-}" ]]; then
+if [[ "${DEVNET:-}" == "true" ]]; then
     echo "🌐 DEVNET set - skipping local Docker rippled."
 elif [[ "${NO_DOCKER:-false}" == "true" ]]; then
     echo "⚙️  NO_DOCKER set - assuming rippled is already running on ws://localhost:6006."

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -14,10 +14,11 @@ echo "🔧 Running end-to-end tests..."
 # Keep node_modules in sync with package-lock.json (e.g. after a package.json bump)
 npm ls --silent > /dev/null 2>&1 || npm ci
 
-# By default, tests run against a local rippled started in Docker, pinned to the
-# same image CI uses (see scripts/docker-rippled.sh). Override with:
+# By default, tests run against a local rippled. scripts/docker-rippled.sh reuses one
+# that's already running on ws://localhost:6006, or else starts one in Docker, pinned to
+# the same image CI uses. Override with:
 #   DEVNET=true      - test against wss://wasm.devnet.rippletest.net:51233 instead
-#   NO_DOCKER=true   - test against a rippled you're already running yourself on ws://localhost:6006
+#   NO_DOCKER=true   - force-skip Docker; test against a rippled you're already running yourself
 if [[ "${DEVNET:-}" == "true" || -n "${DEVNET:-}" ]]; then
     echo "🌐 DEVNET set - skipping local Docker rippled."
 elif [[ "${NO_DOCKER:-false}" == "true" ]]; then

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -11,6 +11,21 @@ cd "$REPO_ROOT"
 
 echo "🔧 Running end-to-end tests..."
 
+# Keep node_modules in sync with package-lock.json (e.g. after a package.json bump)
+npm ls --silent > /dev/null 2>&1 || npm ci
+
+# By default, tests run against a local rippled started in Docker, pinned to the
+# same image CI uses (see scripts/docker-rippled.sh). Override with:
+#   DEVNET=true      - test against wss://wasm.devnet.rippletest.net:51233 instead
+#   NO_DOCKER=true   - test against a rippled you're already running yourself on ws://localhost:6006
+if [[ "${DEVNET:-}" == "true" || -n "${DEVNET:-}" ]]; then
+    echo "🌐 DEVNET set - skipping local Docker rippled."
+elif [[ "${NO_DOCKER:-false}" == "true" ]]; then
+    echo "⚙️  NO_DOCKER set - assuming rippled is already running on ws://localhost:6006."
+else
+    scripts/docker-rippled.sh start
+fi
+
 # Ensure wasm32 target is available
 echo "📦 Ensuring wasm32v1-none target is installed..."
 rustup target add wasm32v1-none

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -34,11 +34,13 @@ echo "   You can optionally install pre-commit locally for development:"
 echo "   - macOS: brew install pre-commit && pre-commit install"
 echo "   - pip: pip install pre-commit && pre-commit install"
 
-# Install Node.js dependencies if needed for host function audit
+# Install Node.js dependencies (host function audit, sfield/tx-flag generation, integration tests)
 if command -v node &> /dev/null; then
-    echo "✅ Node.js found for host function audit"
+    echo "✅ Node.js found: $(node --version)"
+    echo "📦 Installing npm dependencies..."
+    npm ci
 else
-    echo "⚠️  Node.js not found. Host function audit will be skipped."
+    echo "⚠️  Node.js not found. Host function audit and integration tests will be skipped."
 fi
 
 echo "✅ Setup complete!"


### PR DESCRIPTION
Use Docker locally, by default, for e2e-tests during `build-all.sh`. Also, update npm dependencies if needed to work with the current Docker image, and update documentation re: Docker.