### PR TITLE
fix: Decode NFT taxon and serial as little-endian

### DIFF
--- a/e2e-tests/host_functions_test/src/lib.rs
+++ b/e2e-tests/host_functions_test/src/lib.rs
@@ -111,7 +111,7 @@ fn test_ledger_header_functions() -> i32 {
         trace_num("ERROR: ldgr_index failed:", sqn_result as i64);
         return -101; // Ledger sequence number test failed
     }
-    let ledger_sqn = u32::from_be_bytes(sqn_buffer);
+    let ledger_sqn = u32::from_le_bytes(sqn_buffer);
     trace_num("Ledger sequence number:", ledger_sqn as i64);
 
     // Test 1.2: parent_ldgr_time() - should return parent ledger timestamp
@@ -123,7 +123,7 @@ fn test_ledger_header_functions() -> i32 {
         trace_num("ERROR: parent_ldgr_time failed:", time_result as i64);
         return -102; // Parent ledger time test failed
     }
-    let parent_ledger_time = u32::from_be_bytes(time_buffer);
+    let parent_ledger_time = u32::from_le_bytes(time_buffer);
     trace_num("Parent ledger time:", parent_ledger_time as i64);
 
     // Test 1.3: parent_ldgr_hash() - should return parent ledger hash (32 bytes)
@@ -598,7 +598,7 @@ fn test_id_generation_functions() -> i32 {
     // Test 5.3: escrow_id() - Generate ledger entry ID for escrow
     let mut escrow_id_buffer = [0u8; 32];
     let seq: i32 = 1000;
-    let seq_bytes = seq.to_be_bytes();
+    let seq_bytes = seq.to_le_bytes();
     let escrow_id_result = unsafe {
         host::escrow_id(
             account_id.0.as_ptr(),
@@ -619,7 +619,7 @@ fn test_id_generation_functions() -> i32 {
     // Test 5.4: oracle_id() - Generate ledger entry ID for oracle
     let mut oracle_id_buffer = [0u8; 32];
     let document_id: i32 = 42;
-    let document_id_bytes = document_id.to_be_bytes();
+    let document_id_bytes = document_id.to_le_bytes();
     let oracle_id_result = unsafe {
         host::oracle_id(
             account_id.0.as_ptr(),

--- a/skills/xrpl-smart-escrows/reference/patterns.md
+++ b/skills/xrpl-smart-escrows/reference/patterns.md
@@ -120,7 +120,7 @@ fn check_ledger_sqn(_ctx: EscrowFinishContext) -> i32 {
         if match_result_code_with_expected_bytes(rc, 4, || Some(rc)).is_err() {
             return rc;
         }
-        let ledger_sequence = u32::from_be_bytes(buf);
+        let ledger_sequence = u32::from_le_bytes(buf);
         (ledger_sequence >= 5) as i32
     }
 }

--- a/xrpl-common-stdlib/src/types/nft.rs
+++ b/xrpl-common-stdlib/src/types/nft.rs
@@ -262,8 +262,7 @@ impl NFToken {
 
         match result {
             code if code > 0 => {
-                // Convert big-endian bytes to u32
-                let taxon = u32::from_be_bytes(taxon_buf);
+                let taxon = u32::from_le_bytes(taxon_buf);
                 Result::Ok(taxon)
             }
             code => Result::Err(Error::from_code(code)),
@@ -294,8 +293,7 @@ impl NFToken {
 
         match result {
             code if code > 0 => {
-                // Convert big-endian bytes to u32
-                let serial = u32::from_be_bytes(serial_buf);
+                let serial = u32::from_le_bytes(serial_buf);
                 Result::Ok(serial)
             }
             code => Result::Err(Error::from_code(code)),
@@ -606,17 +604,23 @@ mod tests {
         let mut mock = MockHostBindings::new();
         let nft_id = [0u8; 32];
 
-        // Set up expectations - taxon is a u32 (4 bytes)
+        // Non-palindromic so a byte-order regression changes the decoded value.
+        const TAXON: u32 = 0x0102_0304;
+
+        // Set up expectations - the host writes the taxon as 4 little-endian bytes
         mock.expect_nft_taxon()
             .with(always(), eq(NFT_ID_SIZE), always(), eq(4))
-            .returning(|_, _, _, _| 4);
+            .returning(|_, _, out_buff_ptr, _| {
+                unsafe { out_buff_ptr.copy_from_nonoverlapping(TAXON.to_le_bytes().as_ptr(), 4) }
+                4
+            });
 
         let _guard = setup_mock(mock);
 
         let nft = NFToken::new(nft_id);
         let result = nft.taxon();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
+        assert_eq!(result.unwrap(), TAXON);
     }
 
     #[test]
@@ -624,17 +628,23 @@ mod tests {
         let mut mock = MockHostBindings::new();
         let nft_id = [0u8; 32];
 
-        // Set up expectations - serial is a u32 (4 bytes)
+        // Non-palindromic so a byte-order regression changes the decoded value.
+        const SERIAL: u32 = 0x0102_0304;
+
+        // Set up expectations - the host writes the serial as 4 little-endian bytes
         mock.expect_nft_serial()
             .with(always(), eq(NFT_ID_SIZE), always(), eq(4))
-            .returning(|_, _, _, _| 4);
+            .returning(|_, _, out_buff_ptr, _| {
+                unsafe { out_buff_ptr.copy_from_nonoverlapping(SERIAL.to_le_bytes().as_ptr(), 4) }
+                4
+            });
 
         let _guard = setup_mock(mock);
 
         let nft = NFToken::new(nft_id);
         let result = nft.token_sequence();
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
+        assert_eq!(result.unwrap(), SERIAL);
     }
 
     #[test]


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

The PR title must follow the Conventional Commits format:
  <type>: <Description>

The description must start with a capital letter.
Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, release, example.
See CONTRIBUTING.md for details.
-->

## High Level Overview of Change
`NFToken::taxon()` and `NFToken::token_sequence()` decoded the host's 4-byte result with `from_be_bytes`. xrpld writes every scalar host result little-endian (same path as `ldgr_index`), so any non-palindromic value came back byte-reversed. Switched both to `from_le_bytes` and fixed the comments.                                                                                                                                            
                                                                                                                                                       
  The two unit tests now have the mock write `0x01020304` little-endian and assert that value, so a byte-order regression fails instead of passing on  an all-zero buffer.                                                                                                                                  
                                                                                                                                                       
  Also flipped the same mistake in the e2e host-function probe (`ldgr_index`/`parent_ldgr_time` decodes and `escrow_id`/`oracle_id` sequence inputs)    and in the skill doc's `ldgr_index` example.                                                                                                         
                                                                                                                                                       
  Not touched: `from_be_bytes` on XRPL wire-format blobs (STAmount, MPT id, IOU number), which are legitimately big-endian.


### Type of Change

<!--
Please check [x] relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (added tests for existing code, or tests for the new feature in this PR)
- [ ] Documentation update
- [ ] Build / CI / tooling change
- [ ] Release

<!--
## Test Plan
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
